### PR TITLE
Remove trailing comma from Swift source for compat to Swift < 6.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
             publicHeadersPath: "include",
             linkerSettings: [
                 .linkedFramework("Virtualization"),
-            ],
+            ]
         ),
         // Swift executable
         .executableTarget(
@@ -34,7 +34,7 @@ let package = Package(
             linkerSettings: [
                 .linkedFramework("Virtualization"),
                 .linkedFramework("AppKit"),
-            ],
-        ),
-    ],
+            ]
+        )
+    ]
 )

--- a/sources/vphone-cli/VPhoneCLI.swift
+++ b/sources/vphone-cli/VPhoneCLI.swift
@@ -19,7 +19,7 @@ struct VPhoneCLI: AsyncParsableCommand {
 
         Example:
           vphone-cli --rom firmware/rom.bin --disk firmware/disk.img
-        """,
+        """
     )
 
     @Option(help: "Path to the AVPBooter / ROM binary")
@@ -98,7 +98,7 @@ struct VPhoneCLI: AsyncParsableCommand {
             sepRomURL: sepRomURL,
             serialLogPath: serialLog,
             stopOnPanic: stopOnPanic,
-            stopOnFatalError: stopOnFatalError,
+            stopOnFatalError: stopOnFatalError
         )
 
         let vm = try VPhoneVM(options: options)

--- a/sources/vphone-cli/VPhoneVM.swift
+++ b/sources/vphone-cli/VPhoneVM.swift
@@ -48,7 +48,7 @@ class VPhoneVM: NSObject, VZVirtualMachineDelegate {
         let auxStorage = try VZMacAuxiliaryStorage(
             creatingStorageAt: options.nvramURL,
             hardwareModel: hwModel,
-            options: .allowOverwrite,
+            options: .allowOverwrite
         )
         platform.auxiliaryStorage = auxStorage
         platform.hardwareModel = hwModel


### PR DESCRIPTION
On my macOS 15 machine, Swift 6.0 is installed. Swift < 6.1 does not support trailing comma, which can cause failure in compiling.

This PR removes trailing comma to improve portability.