### PR TITLE
Fix check_tools to detect GNU libtool instead of Xcode libtool

### DIFF
--- a/scripts/setup_libimobiledevice.sh
+++ b/scripts/setup_libimobiledevice.sh
@@ -30,9 +30,11 @@ die() { echo "[-] $*" >&2; exit 1; }
 
 check_tools() {
     local missing=()
-    for cmd in autoconf automake libtool pkg-config cmake git; do
+    for cmd in autoconf automake pkg-config cmake git; do
         command -v "$cmd" &>/dev/null || missing+=("$cmd")
     done
+    command -v glibtoolize &>/dev/null || command -v libtoolize &>/dev/null \
+        || missing+=("libtool(ize)")
     (( ${#missing[@]} == 0 )) || die "Missing: ${missing[*]} — brew install ${missing[*]}"
 }
 


### PR DESCRIPTION
The preflight check was looking for `libtool`, which matched Apple's Xcode libtool (/usr/bin/libtool) rather than the GNU libtool needed by autotools. Now checks for `glibtoolize`/`libtoolize` so the build fails early with a clear message when GNU libtool is missing.