### PR TITLE
feat: unlock VM automatically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,8 @@ help:
 	@echo "  make build                   Build + sign vphone-cli"
 	@echo "  make install                 Build + copy to ./bin/"
 	@echo "  make clean                   Remove .build/"
+	@echo "  make unlock                  Cross-compile unlock for arm64-ios"
+	@echo "  make unlock_deploy           Build + deploy unlock to VM via SSH"
 	@echo ""
 	@echo "VM management:"
 	@echo "  make vm_new                  Create VM directory"
@@ -77,7 +79,7 @@ setup_libimobiledevice:
 # Build
 # ═══════════════════════════════════════════════════════════════════
 
-.PHONY: build install clean
+.PHONY: build install clean unlock unlock_deploy
 
 build: $(BINARY)
 
@@ -97,6 +99,24 @@ install: build
 clean:
 	swift package clean
 	rm -rf .build
+
+unlock:
+	clang -arch arm64 -target arm64-apple-ios15.0 \
+		-o $(VM_DIR)/unlock $(SCRIPTS)/unlock.c
+	$(VM_DIR)/cfw_input/tools/ldid_macosx_arm64 -S$(SCRIPTS)/unlock.entitlements -M -K$(VM_DIR)/cfw_input/signcert.p12 $(VM_DIR)/unlock
+	@echo "Built $(VM_DIR)/unlock (arm64-ios)"
+
+SSHPASS      := $(VM_DIR)/cfw_input/tools/sshpass
+SSH_PASS     := alpine
+VM_SSH_PORT  := 22222
+VM_SSH_HOST  := root@localhost
+VM_SSH_OPTS  := -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=3 -q
+
+unlock_deploy: unlock
+	@echo "[*] Deploying unlock to localhost:/var/root/unlock..."
+	$(SSHPASS) -p $(SSH_PASS) ssh $(VM_SSH_OPTS) -p $(VM_SSH_PORT) $(VM_SSH_HOST) \
+		'/iosbinpack64/bin/cat > /var/root/unlock && /iosbinpack64/bin/chmod +x /var/root/unlock' < $(VM_DIR)/unlock
+	@echo "[+] Deployed"
 
 # ═══════════════════════════════════════════════════════════════════
 # VM management
@@ -173,8 +193,8 @@ ramdisk_send:
 
 .PHONY: cfw_install cfw_install_jb
 
-cfw_install:
+cfw_install: unlock
 	cd $(VM_DIR) && zsh "$(CURDIR)/$(SCRIPTS)/cfw_install.sh" .
 
-cfw_install_jb:
+cfw_install_jb: unlock
 	cd $(VM_DIR) && zsh "$(CURDIR)/$(SCRIPTS)/cfw_install_jb.sh" .

--- a/scripts/cfw_install.sh
+++ b/scripts/cfw_install.sh
@@ -292,6 +292,19 @@ ssh_cmd "/bin/rm -f /mnt1/iosbinpack64.tar"
 
 echo "  [+] iosbinpack64 installed"
 
+# ═══════════ 4.5 INSTALL VPHOME (unlock tool) ════════════════
+UNLOCK_BIN="$VM_DIR/unlock"
+if [[ -f "$UNLOCK_BIN" ]]; then
+    echo ""
+    echo "[*] Installing unlock..."
+    scp_to "$UNLOCK_BIN" "/mnt1/iosbinpack64/bin/unlock"
+    ssh_cmd "/bin/chmod 0755 /mnt1/iosbinpack64/bin/unlock"
+    echo "  [+] unlock installed to /iosbinpack64/bin/unlock"
+else
+    echo ""
+    echo "[*] Skipping unlock (not built — run 'make unlock' first)"
+fi
+
 # ═══════════ 5/7 PATCH LAUNCHD_CACHE_LOADER ══════════════════
 echo ""
 echo "[5/7] Patching launchd_cache_loader..."

--- a/scripts/unlock.c
+++ b/scripts/unlock.c
@@ -1,0 +1,119 @@
+// unlock — dispatch Consumer Menu (Home) IOHIDEvent from inside the VM
+// Replicates TrollVNC STHIDEventGenerator._sendHIDEvent pattern:
+//   - dispatch_once client creation
+//   - dispatch_async on serial queue with setSenderID inside block
+
+#include <dlfcn.h>
+#include <dispatch/dispatch.h>
+#include <mach/mach_time.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+typedef const void *CFTypeRef;
+typedef const void *CFAllocatorRef;
+
+#define kHIDPage_Consumer       0x0C
+#define kHIDUsage_Csmr_Menu     0x40
+#define kIOHIDEventOptionNone   0
+
+typedef CFTypeRef (*CreateClient_t)(CFAllocatorRef);
+typedef CFTypeRef (*CreateKbEvent_t)(CFAllocatorRef, uint64_t, uint32_t, uint32_t, int, uint32_t);
+typedef void (*SetSenderID_t)(CFTypeRef, uint64_t);
+typedef void (*DispatchEvent_t)(CFTypeRef, CFTypeRef);
+typedef void (*CFRelease_t)(CFTypeRef);
+typedef CFTypeRef (*CFRetain_t)(CFTypeRef);
+
+static CreateClient_t   g_createClient;
+static CreateKbEvent_t  g_createKbEvent;
+static SetSenderID_t    g_setSenderID;
+static DispatchEvent_t  g_dispatchEvent;
+static CFRelease_t      g_cfRelease;
+static CFRetain_t       g_cfRetain;
+static CFAllocatorRef   g_alloc;
+
+static CFTypeRef get_client(void) {
+    static CFTypeRef client = NULL;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        client = g_createClient(g_alloc);
+        printf("[unlock] client=%p\n", client);
+    });
+    return client;
+}
+
+static void send_hid_event(CFTypeRef event, dispatch_queue_t queue) {
+    if (!event) return;
+    CFTypeRef retained = g_cfRetain(event);
+    dispatch_async(queue, ^{
+        g_setSenderID(retained, 0x8000000817319372ULL);
+        g_dispatchEvent(get_client(), retained);
+        g_cfRelease(retained);
+    });
+}
+
+int main(void) {
+    void *cf = dlopen("/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation", RTLD_NOW);
+    if (!cf) { fprintf(stderr, "[unlock] dlopen CF: %s\n", dlerror()); return 1; }
+
+    g_cfRelease = (CFRelease_t)dlsym(cf, "CFRelease");
+    g_cfRetain = (CFRetain_t)dlsym(cf, "CFRetain");
+    CFAllocatorRef *pAlloc = (CFAllocatorRef *)dlsym(cf, "kCFAllocatorDefault");
+    if (!g_cfRelease || !g_cfRetain || !pAlloc) { fprintf(stderr, "[unlock] CF syms\n"); return 1; }
+    g_alloc = *pAlloc;
+
+    void *iokit = dlopen("/System/Library/Frameworks/IOKit.framework/IOKit", RTLD_NOW);
+    if (!iokit) { fprintf(stderr, "[unlock] dlopen IOKit: %s\n", dlerror()); return 1; }
+
+    g_createClient = (CreateClient_t)dlsym(iokit, "IOHIDEventSystemClientCreate");
+    g_createKbEvent = (CreateKbEvent_t)dlsym(iokit, "IOHIDEventCreateKeyboardEvent");
+    g_setSenderID = (SetSenderID_t)dlsym(iokit, "IOHIDEventSetSenderID");
+    g_dispatchEvent = (DispatchEvent_t)dlsym(iokit, "IOHIDEventSystemClientDispatchEvent");
+
+    if (!g_createClient || !g_createKbEvent || !g_setSenderID || !g_dispatchEvent) {
+        fprintf(stderr, "[unlock] IOKit syms\n"); return 1;
+    }
+
+    dispatch_queue_attr_t attr = dispatch_queue_attr_make_with_qos_class(
+        DISPATCH_QUEUE_SERIAL, QOS_CLASS_USER_INTERACTIVE, 0);
+    dispatch_queue_t queue = dispatch_queue_create("com.unlock.hid-events", attr);
+
+    printf("[unlock] sending Menu (Home) x2 (1.5s gap)...\n");
+
+    // First press — wakes screen
+    CFTypeRef d1 = g_createKbEvent(g_alloc, mach_absolute_time(),
+        kHIDPage_Consumer, kHIDUsage_Csmr_Menu, 1, kIOHIDEventOptionNone);
+    send_hid_event(d1, queue);
+    g_cfRelease(d1);
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 50 * NSEC_PER_MSEC), queue, ^{
+        CFTypeRef u1 = g_createKbEvent(g_alloc, mach_absolute_time(),
+            kHIDPage_Consumer, kHIDUsage_Csmr_Menu, 0, kIOHIDEventOptionNone);
+        send_hid_event(u1, queue);
+        g_cfRelease(u1);
+
+        // Second press — unlocks (1.5s delay avoids App Switcher double-tap)
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 1500 * NSEC_PER_MSEC), queue, ^{
+            CFTypeRef d2 = g_createKbEvent(g_alloc, mach_absolute_time(),
+                kHIDPage_Consumer, kHIDUsage_Csmr_Menu, 1, kIOHIDEventOptionNone);
+            send_hid_event(d2, queue);
+            g_cfRelease(d2);
+
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 50 * NSEC_PER_MSEC), queue, ^{
+                CFTypeRef u2 = g_createKbEvent(g_alloc, mach_absolute_time(),
+                    kHIDPage_Consumer, kHIDUsage_Csmr_Menu, 0, kIOHIDEventOptionNone);
+                send_hid_event(u2, queue);
+                g_cfRelease(u2);
+
+                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 200 * NSEC_PER_MSEC), queue, ^{
+                    printf("[unlock] done\n");
+                    exit(0);
+                });
+            });
+        });
+    });
+
+    dispatch_main();
+    return 0;
+}

--- a/scripts/unlock.entitlements
+++ b/scripts/unlock.entitlements
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>platform-application</key>
+	<true/>
+	<key>com.apple.private.security.no-container</key>
+	<true/>
+	<key>com.apple.private.hid.client.event-dispatch</key>
+	<true/>
+	<key>com.apple.private.hid.client.event-filter</key>
+	<true/>
+	<key>com.apple.private.hid.client.event-monitor</key>
+	<true/>
+	<key>com.apple.private.hid.client.service-protected</key>
+	<true/>
+	<key>com.apple.private.hid.manager.client</key>
+	<true/>
+	<key>com.apple.backboard.client</key>
+	<true/>
+</dict>
+</plist>

--- a/sources/vphone-cli/VPhoneAppDelegate.swift
+++ b/sources/vphone-cli/VPhoneAppDelegate.swift
@@ -83,7 +83,7 @@ class VPhoneAppDelegate: NSObject, NSApplicationDelegate {
         try await vm.start(forceDFU: cli.dfu)
 
         if !cli.noGraphics {
-            let keyHelper = VPhoneKeyHelper(vm: vm.virtualMachine)
+            let keyHelper = VPhoneKeyHelper(vm: vm.virtualMachine, serialWriteHandle: vm.serialWriteHandle)
             let wc = VPhoneWindowController()
             wc.showWindow(
                 for: vm.virtualMachine,
@@ -94,6 +94,10 @@ class VPhoneAppDelegate: NSObject, NSApplicationDelegate {
             )
             windowController = wc
             menuController = VPhoneMenuController(keyHelper: keyHelper)
+
+            if !cli.dfu {
+                keyHelper.autoUnlock(delay: 8)
+            }
         }
     }
 

--- a/sources/vphone-cli/VPhoneMenuController.swift
+++ b/sources/vphone-cli/VPhoneMenuController.swift
@@ -30,6 +30,7 @@ class VPhoneMenuController {
 
         // iOS hardware keyboard shortcuts
         keysMenu.addItem(makeItem("Home Screen (Cmd+H)", action: #selector(sendHome)))
+        keysMenu.addItem(makeItem("Unlock", action: #selector(sendUnlock)))
         keysMenu.addItem(makeItem("Spotlight (Cmd+Space)", action: #selector(sendSpotlight)))
         keysMenu.addItem(NSMenuItem.separator())
         keysMenu.addItem(makeItem("Return", action: #selector(sendReturn)))
@@ -73,6 +74,10 @@ class VPhoneMenuController {
 
     @objc private func sendHome() {
         keyHelper.sendHome()
+    }
+
+    @objc private func sendUnlock() {
+        keyHelper.sendUnlock()
     }
 
     @objc private func sendSpotlight() {

--- a/sources/vphone-cli/VPhoneVM.swift
+++ b/sources/vphone-cli/VPhoneVM.swift
@@ -6,6 +6,10 @@ import Virtualization
 @MainActor
 class VPhoneVM: NSObject, VZVirtualMachineDelegate {
     let virtualMachine: VZVirtualMachine
+    /// Write handle to inject commands into the VM's serial console.
+    private(set) var serialWriteHandle: FileHandle?
+    /// Read handle for VM serial output.
+    private var serialOutputReadHandle: FileHandle?
 
     struct Options {
         var romURL: URL
@@ -102,12 +106,31 @@ class VPhoneVM: NSObject, VZVirtualMachineDelegate {
         net.attachment = VZNATNetworkDeviceAttachment()
         config.networkDevices = [net]
 
-        // Serial port (PL011 UART — interactive stdin/stdout)
+        // Serial port (PL011 UART — pipes for input/output with boot detection)
         if let serialPort = Dynamic._VZPL011SerialPortConfiguration().asObject as? VZSerialPortConfiguration {
+            let inputPipe = Pipe()
+            let outputPipe = Pipe()
+            self.serialWriteHandle = inputPipe.fileHandleForWriting
+
             serialPort.attachment = VZFileHandleSerialPortAttachment(
-                fileHandleForReading: FileHandle.standardInput,
-                fileHandleForWriting: FileHandle.standardOutput
+                fileHandleForReading: inputPipe.fileHandleForReading,
+                fileHandleForWriting: outputPipe.fileHandleForWriting
             )
+
+            // Forward host stdin → VM serial input
+            let writeHandle = inputPipe.fileHandleForWriting
+            let stdinFD = FileHandle.standardInput.fileDescriptor
+            DispatchQueue.global(qos: .userInteractive).async {
+                var buf = [UInt8](repeating: 0, count: 4096)
+                while true {
+                    let n = read(stdinFD, &buf, buf.count)
+                    if n <= 0 { break }
+                    writeHandle.write(Data(buf[..<n]))
+                }
+            }
+
+            serialOutputReadHandle = outputPipe.fileHandleForReading
+
             config.serialPorts = [serialPort]
             print("[vphone] PL011 serial port attached (interactive)")
         }
@@ -139,6 +162,15 @@ class VPhoneVM: NSObject, VZVirtualMachineDelegate {
         virtualMachine = VZVirtualMachine(configuration: config)
         super.init()
         virtualMachine.delegate = self
+
+        // Forward VM serial output → host stdout
+        if let readHandle = serialOutputReadHandle {
+            readHandle.readabilityHandler = { handle in
+                let data = handle.availableData
+                if data.isEmpty { return }
+                FileHandle.standardOutput.write(data)
+            }
+        }
     }
 
     // MARK: - Start

--- a/sources/vphone-cli/VPhoneVMView.swift
+++ b/sources/vphone-cli/VPhoneVMView.swift
@@ -24,6 +24,9 @@ class VPhoneVMView: VZVirtualMachineView {
     // MARK: - Event Handling
 
     override func mouseDown(with event: NSEvent) {
+        // macOS 16+: VZVirtualMachineView handles mouse-to-touch natively
+        if #available(macOS 16.0, *) { super.mouseDown(with: event); return }
+
         let location = self.convert(event.locationInWindow, from: nil)
         
         self.currentTouchSwipeAim = hitTestEdge(at: location)
@@ -36,6 +39,8 @@ class VPhoneVMView: VZVirtualMachineView {
     }
 
     override func mouseDragged(with event: NSEvent) {
+        if #available(macOS 16.0, *) { super.mouseDragged(with: event); return }
+
         sendTouchEvent(
             phase: 1, // Moved
             locationInWindow: event.locationInWindow,
@@ -45,6 +50,8 @@ class VPhoneVMView: VZVirtualMachineView {
     }
 
     override func mouseUp(with event: NSEvent) {
+        if #available(macOS 16.0, *) { super.mouseUp(with: event); return }
+
         sendTouchEvent(
             phase: 3, // Ended
             locationInWindow: event.locationInWindow,
@@ -61,7 +68,7 @@ class VPhoneVMView: VZVirtualMachineView {
         keyHelper.sendHome()
     }
 
-    // MARK: - Touch Injection Logic
+    // MARK: - Legacy Touch Injection (macOS 15)
 
     private func sendTouchEvent(phase: Int, locationInWindow: NSPoint, timestamp: TimeInterval) {
         guard let device = multiTouchDevice,


### PR DESCRIPTION
 ## Summary                                                                                     
                                                                                                 
  - Add `unlock` tool — a small C program that dispatches IOHIDEvent Consumer Menu (Home button) 
  events from inside the VM to wake and unlock the screen                                        
  - Rework serial port to use pipes instead of raw stdin/stdout, enabling programmatic command
  injection alongside interactive use
  - Auto-unlock on non-DFU boot: sends the unlock command via serial console 8 seconds after VM
  start, so the device is unlocked and ready without needing VNC
  - Add "Unlock" menu item for manual unlock at any time
  - Defer to native `VZVirtualMachineView` mouse-to-touch handling on macOS 16+ (Tahoe)

  ## How it works

  The `unlock` binary runs inside the VM and uses `IOHIDEventSystemClientDispatchEvent` to
  simulate two Home button presses (1.5s apart) — first to wake the screen, second to unlock.
  It's cross-compiled for arm64-ios, signed with HID entitlements, and installed to
  `/iosbinpack64/bin/unlock` during CFW installation. On boot, the host sends the unlock command
  through the serial pipe after an 8-second delay.

  Closes #38
