### PR TITLE
Add tool compatibility fallbacks for gtar and sshpass

### DIFF
--- a/scripts/cfw_install.sh
+++ b/scripts/cfw_install.sh
@@ -33,6 +33,7 @@ SSH_PORT=2222
 SSH_PASS="alpine"
 SSH_USER="root"
 SSH_HOST="localhost"
+SSHPASS_BIN=""
 SSH_OPTS=(
     -o StrictHostKeyChecking=no
     -o UserKnownHostsFile=/dev/null
@@ -44,8 +45,56 @@ SSH_OPTS=(
 # ── Helpers ─────────────────────────────────────────────────────
 die() { echo "[-] $*" >&2; exit 1; }
 
+is_exec_compatible() {
+    local bin="$1"
+    local host_arch file_out archs
+
+    [[ -x "$bin" ]] || return 1
+    host_arch="$(uname -m)"
+    file_out="$(file "$bin" 2>/dev/null || true)"
+
+    # Non Mach-O executables (scripts/wrappers) are accepted.
+    if [[ "$file_out" != *"Mach-O"* ]]; then
+        return 0
+    fi
+
+    if command -v lipo >/dev/null 2>&1; then
+        archs="$(lipo -archs "$bin" 2>/dev/null || true)"
+        [[ -n "$archs" && " $archs " == *" $host_arch "* ]] && return 0
+        return 1
+    fi
+
+    [[ "$file_out" == *"$host_arch"* || "$file_out" == *"universal"* ]]
+}
+
+resolve_sshpass() {
+    local bundled="$VM_DIR/$CFW_INPUT/tools/sshpass"
+    local host_sshpass
+    host_sshpass="$(command -v sshpass 2>/dev/null || true)"
+
+    if is_exec_compatible "$bundled"; then
+        SSHPASS_BIN="$bundled"
+        echo "[+] Using bundled sshpass: $SSHPASS_BIN"
+        return
+    fi
+
+    if [[ -x "$bundled" ]]; then
+        echo "[!] Bundled sshpass is not compatible with host arch ($(uname -m)): $bundled"
+    fi
+
+    if [[ -n "$host_sshpass" ]] && is_exec_compatible "$host_sshpass"; then
+        SSHPASS_BIN="$host_sshpass"
+        echo "[+] Using host sshpass: $SSHPASS_BIN"
+        return
+    fi
+
+    [[ -n "$host_sshpass" ]] && \
+        echo "[!] Host sshpass is present but incompatible with host arch: $host_sshpass"
+    die "No compatible sshpass found. Install one with: brew install hudochenkov/sshpass/sshpass"
+}
+
 _sshpass() {
-    "$VM_DIR/$CFW_INPUT/tools/sshpass" -p "$SSH_PASS" "$@"
+    "$SSHPASS_BIN" -p "$SSH_PASS" "$@"
 }
 
 ssh_cmd() {
@@ -137,6 +186,7 @@ echo "[+] Restore directory: $RESTORE_DIR"
 setup_cfw_input
 INPUT_DIR="$VM_DIR/$CFW_INPUT"
 echo "[+] Input resources: $INPUT_DIR"
+resolve_sshpass
 
 mkdir -p "$TEMP_DIR"
 

--- a/scripts/cfw_install_jb.sh
+++ b/scripts/cfw_install_jb.sh
@@ -39,6 +39,7 @@ SSH_PORT=2222
 SSH_PASS="alpine"
 SSH_USER="root"
 SSH_HOST="localhost"
+SSHPASS_BIN=""
 SSH_OPTS=(
     -o StrictHostKeyChecking=no
     -o UserKnownHostsFile=/dev/null
@@ -50,8 +51,56 @@ SSH_OPTS=(
 # ── Helpers ─────────────────────────────────────────────────────
 die() { echo "[-] $*" >&2; exit 1; }
 
+is_exec_compatible() {
+    local bin="$1"
+    local host_arch file_out archs
+
+    [[ -x "$bin" ]] || return 1
+    host_arch="$(uname -m)"
+    file_out="$(file "$bin" 2>/dev/null || true)"
+
+    # Non Mach-O executables (scripts/wrappers) are accepted.
+    if [[ "$file_out" != *"Mach-O"* ]]; then
+        return 0
+    fi
+
+    if command -v lipo >/dev/null 2>&1; then
+        archs="$(lipo -archs "$bin" 2>/dev/null || true)"
+        [[ -n "$archs" && " $archs " == *" $host_arch "* ]] && return 0
+        return 1
+    fi
+
+    [[ "$file_out" == *"$host_arch"* || "$file_out" == *"universal"* ]]
+}
+
+resolve_sshpass() {
+    local bundled="$VM_DIR/$CFW_INPUT/tools/sshpass"
+    local host_sshpass
+    host_sshpass="$(command -v sshpass 2>/dev/null || true)"
+
+    if is_exec_compatible "$bundled"; then
+        SSHPASS_BIN="$bundled"
+        echo "[+] Using bundled sshpass: $SSHPASS_BIN"
+        return
+    fi
+
+    if [[ -x "$bundled" ]]; then
+        echo "[!] Bundled sshpass is not compatible with host arch ($(uname -m)): $bundled"
+    fi
+
+    if [[ -n "$host_sshpass" ]] && is_exec_compatible "$host_sshpass"; then
+        SSHPASS_BIN="$host_sshpass"
+        echo "[+] Using host sshpass: $SSHPASS_BIN"
+        return
+    fi
+
+    [[ -n "$host_sshpass" ]] && \
+        echo "[!] Host sshpass is present but incompatible with host arch: $host_sshpass"
+    die "No compatible sshpass found. Install one with: brew install hudochenkov/sshpass/sshpass"
+}
+
 _sshpass() {
-    "$VM_DIR/$CFW_INPUT/tools/sshpass" -p "$SSH_PASS" "$@"
+    "$SSHPASS_BIN" -p "$SSH_PASS" "$@"
 }
 
 ssh_cmd() {
@@ -108,6 +157,7 @@ setup_cfw_jb_input
 JB_INPUT_DIR="$VM_DIR/$CFW_JB_INPUT"
 echo ""
 echo "[+] JB input resources: $JB_INPUT_DIR"
+resolve_sshpass
 
 mkdir -p "$TEMP_DIR"
 

--- a/scripts/ramdisk_build.py
+++ b/scripts/ramdisk_build.py
@@ -22,6 +22,7 @@ Prerequisites:
 import gzip
 import glob
 import os
+import platform
 import plistlib
 import shutil
 import subprocess
@@ -155,6 +156,56 @@ def run(cmd, **kwargs):
     return subprocess.run(cmd, check=True, **kwargs)
 
 
+def is_exec_compatible(path):
+    """Return True if an executable is usable on this host arch."""
+    if not path or not os.path.isfile(path) or not os.access(path, os.X_OK):
+        return False
+
+    file_out = subprocess.run(
+        ["file", path], capture_output=True, text=True
+    ).stdout
+
+    # Non-Mach-O executables (scripts/wrappers) are accepted.
+    if "Mach-O" not in file_out:
+        return True
+
+    host_arch = platform.machine()
+    try:
+        archs = subprocess.run(
+            ["lipo", "-archs", path], capture_output=True, text=True, check=True
+        ).stdout.split()
+        return host_arch in archs
+    except Exception:
+        return host_arch in file_out or "universal" in file_out
+
+
+def resolve_tar_extractor(input_dir):
+    """Select tar tool with compatibility fallback and clear diagnostics."""
+    bundled_gtar = os.path.join(input_dir, "tools/gtar")
+    host_gtar = shutil.which("gtar")
+    host_tar = shutil.which("tar")
+    host_arch = platform.machine()
+
+    if is_exec_compatible(bundled_gtar):
+        return bundled_gtar, True, "bundled gtar"
+    if os.path.exists(bundled_gtar):
+        print(f"  [!] Bundled gtar is not compatible with host arch ({host_arch}): {bundled_gtar}")
+
+    if host_gtar and is_exec_compatible(host_gtar):
+        return host_gtar, True, "host gtar"
+    if host_gtar:
+        print(f"  [!] Host gtar is present but incompatible with host arch ({host_arch}): {host_gtar}")
+
+    if host_tar and is_exec_compatible(host_tar):
+        return host_tar, False, "host tar"
+    if host_tar:
+        print(f"  [!] Host tar is present but incompatible with host arch ({host_arch}): {host_tar}")
+
+    print("[-] No compatible tar extractor found.")
+    print("    Install GNU tar with: brew install gnu-tar")
+    sys.exit(1)
+
+
 # ══════════════════════════════════════════════════════════════════
 # Firmware extraction and IM4P creation
 # ══════════════════════════════════════════════════════════════════
@@ -223,6 +274,9 @@ def build_ramdisk(restore_dir, im4m_path, vm_dir, input_dir, output_dir, temp_di
     mountpoint = os.path.join(vm_dir, "SSHRD")
     ramdisk_raw = os.path.join(temp_dir, "ramdisk.raw.dmg")
     ramdisk_custom = os.path.join(temp_dir, "ramdisk1.dmg")
+    tar_bin, tar_is_gnu, tar_label = resolve_tar_extractor(input_dir)
+
+    print(f"  Using archive extractor: {tar_label} ({tar_bin})")
 
     # Extract base ramdisk
     print("  Extracting base ramdisk...")
@@ -251,10 +305,12 @@ def build_ramdisk(restore_dir, im4m_path, vm_dir, input_dir, output_dir, temp_di
              ramdisk_custom, "-owners", "off"])
 
         print("  Injecting SSH tools...")
-        gtar = os.path.join(input_dir, "tools/gtar")
         ssh_tar = os.path.join(input_dir, "ssh.tar.gz")
-        run(["sudo", gtar, "-x", "--no-overwrite-dir",
-             "-f", ssh_tar, "-C", mountpoint])
+        extract_cmd = ["sudo", tar_bin, "-x", "-f", ssh_tar, "-C", mountpoint]
+        if tar_is_gnu:
+            extract_cmd = ["sudo", tar_bin, "-x", "--no-overwrite-dir",
+                           "-f", ssh_tar, "-C", mountpoint]
+        run(extract_cmd)
 
         # Remove unnecessary files
         for rel_path in RAMDISK_REMOVE:


### PR DESCRIPTION
## Summary
This patch adds a small compatibility layer for bundled helper binaries to prevent host-arch mismatches from breaking common workflows.

## What changed
- `scripts/ramdisk_build.py`
  - Added tar extractor resolver with fallback order:
    1. bundled `ramdisk_input/tools/gtar`
    2. host `gtar`
    3. host `tar`
  - Added architecture compatibility checks for Mach-O executables.
  - Added clear English preflight diagnostics and selection logs.

- `scripts/cfw_install.sh`
  - Added `sshpass` resolver with fallback order:
    1. bundled `vm/cfw_input/tools/sshpass`
    2. host `sshpass`
  - Added architecture compatibility checks and explicit diagnostics.

- `scripts/cfw_install_jb.sh`
  - Same `sshpass` compatibility resolver and diagnostics as base installer.

## Why
Multiple users hit failures caused by bundled x86_64 helper binaries on non-x86_64 hosts. This keeps the existing bundled-tool path intact while safely falling back to host tools when needed.

## Validation
- `zsh -n scripts/cfw_install.sh`
- `zsh -n scripts/cfw_install_jb.sh`
- `python3 -m py_compile scripts/ramdisk_build.py`

## Linked issues
- Fixes Lakr233/vphone-cli#41
- Related Lakr233/vphone-cli#39
