### PR TITLE
feat: add host location passthrough to guest VM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,7 @@ let package = Package(
                 .linkedFramework("Virtualization"),
                 .linkedFramework("AppKit"),
                 .linkedFramework("SwiftUI"),
+                .linkedFramework("CoreLocation"),
             ]
         ),
     ]

--- a/scripts/vphoned/entitlements.plist
+++ b/scripts/vphoned/entitlements.plist
@@ -11,6 +11,10 @@
 		<string>data-allowed</string>
 		<string>data-allowed-write</string>
 	</array>
+	<key>com.apple.locationd.preauthorized</key>
+	<true/>
+	<key>com.apple.locationd.simulation</key>
+	<true/>
 	<key>com.apple.Pasteboard.background-access</key>
 	<true/>
 	<key>com.apple.Pasteboard.originating-bundle-id-query</key>

--- a/sources/Info.plist
+++ b/sources/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleIdentifier</key>
+	<string>com.vphone.cli</string>
+	<key>CFBundleExecutable</key>
+	<string>vphone-cli</string>
+	<key>CFBundleName</key>
+	<string>vphone-cli</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>LSUIElement</key>
+	<true/>
+	<key>NSLocationUsageDescription</key>
+	<string>vphone-cli forwards your location to the guest VM for location simulation.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>vphone-cli forwards your location to the guest VM for location simulation.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>vphone-cli forwards your location to the guest VM for location simulation.</string>
+</dict>
+</plist>

--- a/sources/vphone-cli/VPhoneLocationProvider.swift
+++ b/sources/vphone-cli/VPhoneLocationProvider.swift
@@ -1,0 +1,109 @@
+import CoreLocation
+import Foundation
+
+/// Forwards the host Mac's location to the guest VM via vsock.
+///
+/// Uses macOS CoreLocation to track the Mac's real location and forwards
+/// every update to the guest.  Call `startForwarding()` when the guest
+/// reports "location" capability.  Safe to call multiple times (e.g.
+/// after vphoned reconnects) — re-sends the last known position.
+@MainActor
+class VPhoneLocationProvider: NSObject {
+    private let control: VPhoneControl
+    private var hostModeStarted = false
+
+    private var locationManager: CLLocationManager?
+    private var delegateProxy: LocationDelegateProxy?
+    private var lastLocation: CLLocation?
+
+    init(control: VPhoneControl) {
+        self.control = control
+        super.init()
+
+        let proxy = LocationDelegateProxy { [weak self] location in
+            Task { @MainActor in
+                self?.forward(location)
+            }
+        }
+        self.delegateProxy = proxy
+        let mgr = CLLocationManager()
+        mgr.delegate = proxy
+        mgr.desiredAccuracy = kCLLocationAccuracyBest
+        self.locationManager = mgr
+        print("[location] host location forwarding ready")
+    }
+
+    /// Begin sending location to the guest.  Safe to call on every (re)connect.
+    func startForwarding() {
+        guard let mgr = locationManager else { return }
+        mgr.requestAlwaysAuthorization()
+        mgr.startUpdatingLocation()
+        hostModeStarted = true
+        print("[location] started host location tracking")
+        // Re-send last known location immediately on reconnect
+        if let last = lastLocation {
+            forward(last)
+            print("[location] re-sent last known host location")
+        }
+    }
+
+    /// Stop forwarding and clear the simulated location in the guest.
+    func stopForwarding() {
+        if hostModeStarted {
+            locationManager?.stopUpdatingLocation()
+            hostModeStarted = false
+            print("[location] stopped host location tracking")
+        }
+    }
+
+    private func forward(_ location: CLLocation) {
+        lastLocation = location
+        guard control.isConnected else {
+            print("[location] forward: not connected, cached for later")
+            return
+        }
+        control.sendLocation(
+            latitude: location.coordinate.latitude,
+            longitude: location.coordinate.longitude,
+            altitude: location.altitude,
+            horizontalAccuracy: location.horizontalAccuracy,
+            verticalAccuracy: location.verticalAccuracy,
+            speed: location.speed,
+            course: location.course
+        )
+    }
+}
+
+// MARK: - CLLocationManagerDelegate Proxy
+
+/// Separate object to avoid @MainActor vs nonisolated delegate conflicts.
+private class LocationDelegateProxy: NSObject, CLLocationManagerDelegate {
+    let handler: (CLLocation) -> Void
+
+    init(handler: @escaping (CLLocation) -> Void) {
+        self.handler = handler
+    }
+
+    func locationManager(_: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let location = locations.last else { return }
+        NSLog("[location] got location: %.6f,%.6f (±%.0fm)",
+              location.coordinate.latitude, location.coordinate.longitude,
+              location.horizontalAccuracy)
+        handler(location)
+    }
+
+    func locationManager(_: CLLocationManager, didFailWithError error: any Error) {
+        let clErr = (error as NSError).code
+        // kCLErrorLocationUnknown (0) = transient, just waiting for fix
+        if clErr == 0 { return }
+        NSLog("[location] CLLocationManager error: %@ (code %ld)", error.localizedDescription, clErr)
+    }
+
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        let status = manager.authorizationStatus
+        NSLog("[location] authorization status: %d", status.rawValue)
+        if status == .authorized || status == .authorizedAlways {
+            manager.startUpdatingLocation()
+        }
+    }
+}

--- a/sources/vphone.entitlements
+++ b/sources/vphone.entitlements
@@ -10,6 +10,8 @@
 	<true/>
 	<key>com.apple.vm.networking</key>
 	<true/>
+	<key>com.apple.security.personal-information.location</key>
+	<true/>
 	<key>com.apple.security.get-task-allow</key>
 	<true/>
 </dict>


### PR DESCRIPTION
Forward the Mac's native GPS location to the guest iOS VM via the vphoned vsock agent. CLSimulationManager (private API) is used inside the guest to inject coordinates into locationd so that guest apps receive location updates transparently.


Bundle the `vphone-cli` binary into a .app (Info.plist with NSLocationUsageDescription) so macOS grants location permission to the CLI process