### PR TITLE
setup_machine: run preflight checks and fix iproxy validation

### DIFF
--- a/scripts/setup_machine.sh
+++ b/scripts/setup_machine.sh
@@ -232,7 +232,7 @@ wait_for_recovery() {
 start_iproxy_2222() {
   local iproxy_bin
   iproxy_bin="${PROJECT_ROOT}/.limd/bin/iproxy"
-  [[ -n "$iproxy_bin" ]] || die "iproxy not found in PATH"
+  [[ -x "$iproxy_bin" ]] || die "iproxy not found at $iproxy_bin (run: make setup_libimobiledevice)"
 
   mkdir -p "$LOG_DIR"
   : > "$IPROXY_LOG"
@@ -262,6 +262,10 @@ stop_iproxy_2222() {
 }
 
 main() {
+  check_platform
+  install_brew_deps
+  ensure_python_linked
+
   run_make "Project setup" setup_libimobiledevice
   run_make "Project setup" setup_venv
   run_make "Project setup" build


### PR DESCRIPTION
## Summary
This is a small reliability fix for `make setup_machine`.

## Changes
- `scripts/setup_machine.sh`
  - Run existing preflight helpers at the start of `main()`:
    - `check_platform`
    - `install_brew_deps`
    - `ensure_python_linked`
  - Fix `start_iproxy_2222()` validation:
    - before: checked non-empty string (`[[ -n "$iproxy_bin" ]]`) which is always true after assignment
    - now: checks executable path (`[[ -x "$iproxy_bin" ]]`) with an actionable error message

## Why
The script already had preflight helper functions, but they were never invoked. Also, the old `iproxy` check could not catch missing binaries early, leading to avoidable runtime failures later in setup.

## Validation
- `zsh -n scripts/setup_machine.sh`
