### PR TITLE
rpcserver: Add `rpcserver` daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,11 +136,13 @@ In a separate terminal, start iproxy tunnels:
 ```bash
 iproxy 22222 22222   # SSH
 iproxy 5901 5901     # VNC
+iproxy 5910 5910     # RPC
 ```
 
 Connect via:
 - **SSH:** `ssh -p 22222 root@127.0.0.1` (password: `alpine`)
 - **VNC:** `vnc://127.0.0.1:5901`
+- [**RPC:**](http://github.com/doronz88/rpc-project) `rpcclient -p 5910 127.0.0.1`
 
 ## All Make Targets
 

--- a/scripts/cfw_install.sh
+++ b/scripts/cfw_install.sh
@@ -403,7 +403,7 @@ cp "$TEMP_DIR/vphoned" "$VM_DIR/.vphoned.signed"
 echo "  [+] vphoned installed (signed copy at .vphoned.signed)"
 
 # Send daemon plists (overwrite on re-run)
-for plist in bash.plist dropbear.plist trollvnc.plist; do
+for plist in bash.plist dropbear.plist trollvnc.plist rpcserver_ios.plist; do
     scp_to "$INPUT_DIR/jb/LaunchDaemons/$plist" "/mnt1/System/Library/LaunchDaemons/"
     ssh_cmd "/bin/chmod 0644 /mnt1/System/Library/LaunchDaemons/$plist"
 done

--- a/scripts/patchers/cfw.py
+++ b/scripts/patchers/cfw.py
@@ -1018,7 +1018,7 @@ def inject_daemons(plist_path, daemon_dir):
     with open(plist_path, "rb") as f:
         target = plistlib.load(f)
 
-    for name in ("bash", "dropbear", "trollvnc", "vphoned"):
+    for name in ("bash", "dropbear", "trollvnc", "vphoned", "rpcserver_ios"):
         src = os.path.join(daemon_dir, f"{name}.plist")
         if not os.path.exists(src):
             print(f"  [!] Missing {src}, skipping")


### PR DESCRIPTION
Adding rpcserver as a launch daemon provides a clean, powerful RPC interface via the rpcclient Python library (http://github.com/doronz88/rpc-project).

**Useful capabilities**
- HID / touch / keyboard simulation
- Filesystem read/write
- Process listing, memory read/write, injection
- Decrypted app binary dumping
- Objective-C runtime interaction (method calls, class resolution)
- MobileGestalt queries
- XPC, preferences, location spoofing
- Backlight, battery, multimedia control
- And much more — all from Python

This makes the VM as scriptable as a physical jailbroken device and allows reuse of existing frida/objection/rpcclient-based scripts.

**Bonus long-term benefit**  
rpcserver could eventually replace vphoned, reducing the amount of custom code we need to maintain while gaining far more features.

### Proposed Changes
- Fetch latest rpcserver arm64 iOS binary from releases
- Install it into the cfw image
- Add launchd plist to start rpcserver automatically on boot

Feedback appreciated!