### PR TITLE
add wget installation command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Restart once more.
 **Install dependencies:**
 
 ```bash
-brew install gnu-tar openssl@3 ldid-procursus sshpass keystone autoconf automake pkg-config libtool git-lfs
+brew install wget gnu-tar openssl@3 ldid-procursus sshpass keystone autoconf automake pkg-config libtool git-lfs
 ```
 
 **Git LFS** — this repo uses Git LFS for large resource archives. Install and pull before building:


### PR DESCRIPTION
Wget is not available in macos by default


<img width="1792" height="806" alt="CleanShot 2026-03-03 at 03 06 38@2x" src="https://github.com/user-attachments/assets/31cbec59-e16a-42a4-ae7b-1a427bd8ecf3" />
