### PR TITLE
setup_machine: require macOS 15+ and align docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Virtual iPhone boot tool using Apple's Virtualization.framework with PCC researc
 - **Boot (DFU):** `make boot_dfu`
 - **All targets:** `make help`
 - **Python venv:** `make setup_venv` (installs to `.venv/`, activate with `source .venv/bin/activate`)
-- **Platform:** macOS 14+ (Sequoia), SIP/AMFI disabled
+- **Platform:** macOS 15+ (Sequoia), SIP/AMFI disabled
 - **Language:** Swift 6.0 (SwiftPM), private APIs via [Dynamic](https://github.com/mhdhejazi/Dynamic)
 - **Python deps:** `capstone`, `keystone-engine`, `pyimg4` (see `requirements.txt`)
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Boot a virtual iPhone (iOS 26) via Apple's Virtualization.framework using PCC re
 
 ## Prerequisites
 
+**Host OS:** macOS 15+ (Sequoia) is required for PV=3 virtualization.
+
 **Disable SIP and AMFI** — required for private Virtualization.framework entitlements.
 
 Boot into Recovery (long press power button), open Terminal:

--- a/README_ja.md
+++ b/README_ja.md
@@ -16,6 +16,8 @@ Apple の Virtualization.framework と PCC の研究用 VM インフラを使用
 
 ## 前提条件
 
+**ホストOS:** PV=3 仮想化には macOS 15+（Sequoia）が必要です。
+
 **SIPとAMFIを無効化** — プライベートな Virtualization.framework の entitlement を使うために必要です。
 
 復旧モードで起動し（電源ボタンを長押し）、ターミナルを開いて以下を実行します：

--- a/README_ko.md
+++ b/README_ko.md
@@ -16,6 +16,8 @@ PCC 리서치 VM 인프라와 Apple의 Virtualization.framework를 사용하여 
 
 ## 사전 요구 사항
 
+**호스트 OS:** PV=3 가상화를 위해 macOS 15+(Sequoia)가 필요합니다.
+
 **SIP 및 AMFI 비활성화** — Private Virtualization.framework 권한을 사용하기 위해 필요합니다.
 
 복구 모드(전원 버튼 길게 누르기)로 부팅한 후 터미널을 엽니다:

--- a/README_zh.md
+++ b/README_zh.md
@@ -16,6 +16,8 @@
 
 ## 先决条件
 
+**主机系统：** PV=3 虚拟化要求 macOS 15+（Sequoia）。
+
 **禁用 SIP 和 AMFI** —— 需要私有的 Virtualization.framework 权限。
 
 重启到恢复模式（长按电源键），打开终端：

--- a/scripts/setup_machine.sh
+++ b/scripts/setup_machine.sh
@@ -219,8 +219,8 @@ check_platform() {
 
   local major
   major="$(sw_vers -productVersion | cut -d. -f1)"
-  if [[ -z "$major" || "$major" -lt 14 ]]; then
-    die "macOS 14+ required (detected: $(sw_vers -productVersion))"
+  if [[ -z "$major" || "$major" -lt 15 ]]; then
+    die "macOS 15+ required (detected: $(sw_vers -productVersion))"
   fi
 }
 


### PR DESCRIPTION
## Summary
- tighten `setup_machine` host preflight from `macOS 14+` to `macOS 15+`
- align host requirement text across docs:
  - `README.md`
  - `README_zh.md`
  - `README_ja.md`
  - `README_ko.md`
  - `AGENTS.md`

## Why `macOS 15+` is required
This project uses **PV=3** virtualization via private Virtualization.framework paths.

The repository already encodes this requirement in runtime/docs:
- `sources/vphone-cli/VPhoneHardwareModel.swift` comment: minimum host for PV=3 is macOS 15.0
- `sources/vphone-cli/VPhoneCLI.swift` CLI discussion: macOS 15+ required

Before this PR, `scripts/setup_machine.sh` still allowed `macOS 14+`, which created a mismatch:
- users passed preflight
- pipeline progressed into DFU boot
- then failed later with non-actionable runtime errors (e.g. hardware model unsupported / internal virtualization start failure)

That late failure pattern matches current reports in #79 and #76.

## Why this change helps
- converts a **late, expensive failure** into an **early, explicit preflight error**
- reduces confusion around DFU/startup errors that are actually host-version incompatibility
- keeps setup script behavior consistent with existing runtime assumptions and docs

## Scope / Risk
- no VM boot logic change
- no firmware/patching behavior change
- only host gating + documentation consistency
- supported hosts (macOS 15+) are unaffected

## Validation
- `zsh -n scripts/setup_machine.sh`
