### PR TITLE
setup_machine: fail early on ramdisk panic while waiting for SSH

### DIFF
--- a/scripts/setup_machine.sh
+++ b/scripts/setup_machine.sh
@@ -395,6 +395,20 @@ wait_for_ramdisk_ssh() {
 
   echo "[*] Waiting for ramdisk SSH on ${RAMDISK_SSH_USER}@127.0.0.1:${RAMDISK_SSH_PORT} (timeout=${RAMDISK_SSH_TIMEOUT}s)..."
   while (( waited < RAMDISK_SSH_TIMEOUT )); do
+    if [[ -f "$DFU_LOG" ]] && grep -Eiq 'panic|kernel panic|stackshot succeeded|panic\.apple\.com' "$DFU_LOG"; then
+      echo "[-] Detected panic markers in boot_dfu log while waiting for ramdisk SSH."
+      echo "[-] boot_dfu log tail:"
+      tail -n 80 "$DFU_LOG" 2>/dev/null || true
+      die "Ramdisk boot appears to have panicked before SSH became ready."
+    fi
+
+    if [[ -n "$DFU_PID" ]] && ! kill -0 "$DFU_PID" 2>/dev/null; then
+      echo "[-] boot_dfu process exited while waiting for ramdisk SSH."
+      echo "[-] boot_dfu log tail:"
+      tail -n 80 "$DFU_LOG" 2>/dev/null || true
+      die "DFU boot exited before ramdisk SSH became ready."
+    fi
+
     if "$sshpass_bin" -p "$RAMDISK_SSH_PASS" ssh \
       -o StrictHostKeyChecking=no \
       -o UserKnownHostsFile=/dev/null \


### PR DESCRIPTION
## Summary
- improve `wait_for_ramdisk_ssh()` in `scripts/setup_machine.sh` with early failure detection while waiting for SSH:
  - detect panic markers in `setup_logs/boot_dfu.log`
  - detect unexpected `boot_dfu` process exit
- print relevant `boot_dfu` log tail immediately and fail with a specific reason

## Why
Related to #94.

Current behavior can end with a generic SSH timeout even when ramdisk boot already panicked. Users then see a low-signal error (`SSH not ready`) instead of the real root cause (`boot panic` / early DFU exit).

This change surfaces the real failure mode earlier and avoids wasting the full timeout window.

## User-visible effect
Before:
- wait up to timeout
- fail with `Ramdisk SSH did not become ready`

After:
- fail early when panic markers appear or DFU exits
- include immediate `boot_dfu` log tail and explicit error reason

## Validation
- `zsh -n scripts/setup_machine.sh`
