### PR TITLE
Add synthetic battery simulation via Virtualization.framework private…

### DIFF
--- a/sources/vphone-cli/VPhoneAppDelegate.swift
+++ b/sources/vphone-cli/VPhoneAppDelegate.swift
@@ -120,6 +120,7 @@ class VPhoneAppDelegate: NSObject, NSApplicationDelegate {
             fileWindowController = fileWC
 
             let mc = VPhoneMenuController(keyHelper: keyHelper, control: control)
+            mc.vm = vm
             mc.onFilesPressed = { [weak fileWC, weak control] in
                 guard let fileWC, let control else { return }
                 fileWC.showWindow(control: control)

--- a/sources/vphone-cli/VPhoneMenuBattery.swift
+++ b/sources/vphone-cli/VPhoneMenuBattery.swift
@@ -1,0 +1,74 @@
+import AppKit
+
+// MARK: - Battery Menu
+
+extension VPhoneMenuController {
+    func buildBatteryMenu() -> NSMenuItem {
+        let item = NSMenuItem()
+        let menu = NSMenu(title: "Battery")
+
+        // Charge level presets
+        for level in [100, 75, 50, 25, 10, 5] {
+            let mi = makeItem("\(level)%", action: #selector(setBatteryLevel(_:)))
+            mi.tag = level
+            mi.state = level == 100 ? .on : .off
+            menu.addItem(mi)
+        }
+
+        menu.addItem(NSMenuItem.separator())
+
+        // Connectivity: 1=charging, 2=disconnected
+        let charging = makeItem("Charging", action: #selector(setBatteryConnectivity(_:)))
+        charging.tag = 1
+        charging.state = .on
+        let disconnected = makeItem("Disconnected", action: #selector(setBatteryConnectivity(_:)))
+        disconnected.tag = 2
+
+        menu.addItem(charging)
+        menu.addItem(disconnected)
+
+        item.submenu = menu
+        return item
+    }
+
+    @objc func setBatteryLevel(_ sender: NSMenuItem) {
+        guard let menu = sender.menu else { return }
+        for mi in menu.items {
+            if mi.isSeparatorItem { break }
+            mi.state = mi === sender ? .on : .off
+        }
+        let charge = Double(sender.tag)
+        let connectivity = currentBatteryConnectivity(in: menu)
+        vm?.setBattery(charge: charge, connectivity: connectivity)
+        print("[battery] set \(sender.tag)%, connectivity=\(connectivity)")
+    }
+
+    @objc func setBatteryConnectivity(_ sender: NSMenuItem) {
+        guard let menu = sender.menu else { return }
+        var pastSeparator = false
+        for mi in menu.items {
+            if mi.isSeparatorItem { pastSeparator = true; continue }
+            if pastSeparator { mi.state = mi === sender ? .on : .off }
+        }
+        let charge = currentBatteryCharge(in: menu)
+        vm?.setBattery(charge: charge, connectivity: sender.tag)
+        print("[battery] set \(Int(charge))%, connectivity=\(sender.tag)")
+    }
+
+    private func currentBatteryCharge(in menu: NSMenu) -> Double {
+        for mi in menu.items {
+            if mi.isSeparatorItem { break }
+            if mi.state == .on { return Double(mi.tag) }
+        }
+        return 100.0
+    }
+
+    private func currentBatteryConnectivity(in menu: NSMenu) -> Int {
+        var pastSeparator = false
+        for mi in menu.items {
+            if mi.isSeparatorItem { pastSeparator = true; continue }
+            if pastSeparator && mi.state == .on { return mi.tag }
+        }
+        return 1
+    }
+}

--- a/sources/vphone-cli/VPhoneMenuController.swift
+++ b/sources/vphone-cli/VPhoneMenuController.swift
@@ -7,6 +7,7 @@ import Foundation
 class VPhoneMenuController {
     let keyHelper: VPhoneKeyHelper
     let control: VPhoneControl
+    weak var vm: VPhoneVirtualMachine?
 
     var onFilesPressed: (() -> Void)?
     var locationProvider: VPhoneLocationProvider?
@@ -46,6 +47,7 @@ class VPhoneMenuController {
         mainMenu.addItem(buildInstallMenu())
         mainMenu.addItem(buildLocationMenu())
         mainMenu.addItem(buildRecordMenu())
+        mainMenu.addItem(buildBatteryMenu())
 
         NSApp.mainMenu = mainMenu
     }

--- a/sources/vphone-cli/VPhoneVirtualMachine.swift
+++ b/sources/vphone-cli/VPhoneVirtualMachine.swift
@@ -8,6 +8,8 @@ class VPhoneVirtualMachine: NSObject, VZVirtualMachineDelegate {
     let virtualMachine: VZVirtualMachine
     /// Read handle for VM serial output.
     private var serialOutputReadHandle: FileHandle?
+    /// Synthetic battery source for runtime charge/connectivity updates.
+    private var batterySource: AnyObject?
 
     struct Options {
         var romURL: URL
@@ -148,6 +150,18 @@ class VPhoneVirtualMachine: NSObject, VZVirtualMachineDelegate {
         // Vsock (host ↔ guest control channel, no IP/TCP involved)
         config.socketDevices = [VZVirtioSocketDeviceConfiguration()]
 
+        // Power source (synthetic battery — guest sees full charge, charging)
+        let source = Dynamic._VZMacSyntheticBatterySource()
+        source.setCharge(100.0)
+        source.setConnectivity(1) // 1=charging, 2=disconnected
+        let batteryConfig = Dynamic._VZMacBatteryPowerSourceDeviceConfiguration()
+        batteryConfig.setSource(source.asObject)
+        if let batteryObj = batteryConfig.asObject {
+            Dynamic(config)._setPowerSourceDevices([batteryObj])
+            batterySource = source.asObject as AnyObject?
+            print("[vphone] Synthetic battery configured (100%, charging)")
+        }
+
         // GDB debug stub (default init, system-assigned port)
         Dynamic(config)._setDebugStub(Dynamic._VZGDBDebugStubConfiguration().asObject)
 
@@ -176,6 +190,18 @@ class VPhoneVirtualMachine: NSObject, VZVirtualMachineDelegate {
                 FileHandle.standardOutput.write(data)
             }
         }
+    }
+
+    // MARK: - Battery
+
+    /// Update the synthetic battery charge and connectivity at runtime.
+    /// - Parameters:
+    ///   - charge: Battery percentage (0.0–100.0).
+    ///   - connectivity: 1 = charging, 2 = disconnected.
+    func setBattery(charge: Double, connectivity: Int) {
+        guard let source = batterySource else { return }
+        Dynamic(source).setCharge(charge)
+        Dynamic(source).setConnectivity(connectivity)
     }
 
     // MARK: - Start


### PR DESCRIPTION
   - Use `_VZMacSyntheticBatterySource` (Virtualization.framework private API) to inject a virtual power source into the guest VM
   - Guest kernel's `AppleVirtualPlatformPowerSource` driver picks it up automatically via VirtIO — no guest-side changes needed
   - Battery menu in menu bar with level presets (100/75/50/25/10/5%) and charging state toggle (Charging / Disconnected)
   - Runtime-adjustable via `setBattery(charge:connectivity:)` — changes propagate to guest instantly