### PR TITLE
Add kernel GDB debug stub option and validation

### DIFF
--- a/sources/vphone-cli/VPhoneAppDelegate.swift
+++ b/sources/vphone-cli/VPhoneAppDelegate.swift
@@ -62,9 +62,10 @@ class VPhoneAppDelegate: NSObject, NSApplicationDelegate {
         print(
             "Screen: \(cli.screenWidth)x\(cli.screenHeight) @ \(cli.screenPpi) PPI (scale \(cli.screenScale)x)"
         )
-        print("SEP   : enabled")
-        print("  storage: \(cli.sepStorage)")
-        print("  rom    : \(cli.sepRom)")
+        print("Kernel debug stub : 127.0.0.1:\(cli.kernelDebugPort)")
+        print("SEP               : enabled")
+        print("  storage         : \(cli.sepStorage)")
+        print("  rom             : \(cli.sepRom)")
         print("")
 
         let options = VPhoneVirtualMachine.Options(
@@ -79,7 +80,8 @@ class VPhoneAppDelegate: NSObject, NSApplicationDelegate {
             screenWidth: cli.screenWidth,
             screenHeight: cli.screenHeight,
             screenPPI: cli.screenPpi,
-            screenScale: cli.screenScale
+            screenScale: cli.screenScale,
+            kernelDebugPort: cli.kernelDebugPort
         )
 
         let vm = try VPhoneVirtualMachine(options: options)

--- a/sources/vphone-cli/VPhoneCLI.swift
+++ b/sources/vphone-cli/VPhoneCLI.swift
@@ -58,6 +58,9 @@ struct VPhoneCLI: ParsableCommand {
     @Option(help: "Window scale divisor (default: 3.0)")
     var screenScale: Double = 3.0
 
+    @Option(help: "Kernel GDB debug stub port on host (default: 5909)")
+    var kernelDebugPort: Int = 5909
+
     @Flag(help: "Run without GUI (headless)")
     var noGraphics: Bool = false
 

--- a/sources/vphone-cli/VPhoneError.swift
+++ b/sources/vphone-cli/VPhoneError.swift
@@ -4,6 +4,7 @@ enum VPhoneError: Error, CustomStringConvertible {
     case hardwareModelNotSupported
     case romNotFound(String)
     case diskNotFound(String)
+    case invalidKernelDebugPort(Int)
 
     var description: String {
         switch self {
@@ -19,6 +20,8 @@ enum VPhoneError: Error, CustomStringConvertible {
             "ROM not found: \(p)"
         case let .diskNotFound(p):
             "Disk image not found: \(p)"
+        case let .invalidKernelDebugPort(port):
+            "Invalid kernel debug port: \(port) (expected 1...65535)"
         }
     }
 }

--- a/sources/vphone-cli/VPhoneMenuBattery.swift
+++ b/sources/vphone-cli/VPhoneMenuBattery.swift
@@ -67,7 +67,7 @@ extension VPhoneMenuController {
         var pastSeparator = false
         for mi in menu.items {
             if mi.isSeparatorItem { pastSeparator = true; continue }
-            if pastSeparator && mi.state == .on { return mi.tag }
+            if pastSeparator, mi.state == .on { return mi.tag }
         }
         return 1
     }

--- a/sources/vphone-cli/VPhoneVirtualMachine.swift
+++ b/sources/vphone-cli/VPhoneVirtualMachine.swift
@@ -24,6 +24,7 @@ class VPhoneVirtualMachine: NSObject, VZVirtualMachineDelegate {
         var screenHeight: Int = 2796
         var screenPPI: Int = 460
         var screenScale: Double = 3.0
+        var kernelDebugPort: Int = 5909
     }
 
     init(options: Options) throws {
@@ -162,8 +163,19 @@ class VPhoneVirtualMachine: NSObject, VZVirtualMachineDelegate {
             print("[vphone] Synthetic battery configured (100%, charging)")
         }
 
-        // GDB debug stub (default init, system-assigned port)
-        Dynamic(config)._setDebugStub(Dynamic._VZGDBDebugStubConfiguration().asObject)
+        guard (1 ... 65535).contains(options.kernelDebugPort) else {
+            throw VPhoneError.invalidKernelDebugPort(options.kernelDebugPort)
+        }
+
+        // Kernel GDB debug stub (fixed host port for deterministic LLDB attach)
+        let kernelDebugPort = options.kernelDebugPort
+        if let kernelDebugStub = Dynamic._VZGDBDebugStubConfiguration(port: kernelDebugPort).asObject {
+            Dynamic(config)._setDebugStub(kernelDebugStub)
+            print("[vphone] Kernel GDB debug stub: tcp://127.0.0.1:\(kernelDebugPort)")
+        } else {
+            Dynamic(config)._setDebugStub(Dynamic._VZGDBDebugStubConfiguration().asObject)
+            print("[vphone] Kernel GDB debug stub enabled (system-assigned port)")
+        }
 
         // Coprocessors
         let sepConfig = Dynamic._VZSEPCoprocessorConfiguration(storageURL: options.sepStorageURL)


### PR DESCRIPTION
Introduce a kernel debug port option and wire it through the CLI and VM configuration. Adds a --kernelDebugPort CLI option (default 5909), a kernelDebugPort field in VPhoneVirtualMachine.Options, and validation (1..65535) that throws VPhoneError.invalidKernelDebugPort on invalid values. Configure the VM to use a fixed host GDB debug stub port when possible (with system-assigned fallback) and print the chosen stub info from the AppDelegate. Also include a small menu styling tweak (comma-style) in VPhoneMenuBattery.