### PR TITLE
fix: show alert on file transfer failure in File Browser

### DIFF
--- a/sources/vphone-cli/VPhoneFileBrowserModel.swift
+++ b/sources/vphone-cli/VPhoneFileBrowserModel.swift
@@ -172,9 +172,13 @@ class VPhoneFileBrowserModel {
     }
 
     func uploadFiles(urls: [URL]) async {
+        var uploadError: String?
         for url in urls {
-            guard let data = try? Data(contentsOf: url) else { continue }
             let name = url.lastPathComponent
+            guard let data = try? Data(contentsOf: url) else {
+                uploadError = "Could not read \"\(name)\" from disk."
+                break
+            }
             let dest = (currentPath as NSString).appendingPathComponent(name)
             transferName = name
             transferTotal = Int64(data.count)
@@ -184,11 +188,14 @@ class VPhoneFileBrowserModel {
                 transferCurrent = Int64(data.count)
                 print("[files] uploaded \(name) (\(data.count) bytes)")
             } catch {
-                self.error = "Upload failed: \(error)"
+                uploadError = "Upload failed for \"\(name)\": \(error)"
+                break
             }
         }
         transferName = nil
         await refresh()
+        // Set error after refresh so refresh() doesn't clear it before the alert fires.
+        if let e = uploadError { self.error = e }
     }
 
     func createNewFolder(name: String) async {

--- a/sources/vphone-cli/VPhoneFileBrowserView.swift
+++ b/sources/vphone-cli/VPhoneFileBrowserView.swift
@@ -313,7 +313,9 @@ struct VPhoneFileBrowserView: View {
                     urls.append(url)
                 }
             }
-            if !urls.isEmpty {
+            if urls.isEmpty {
+                model.error = "Could not load any files from the dropped items."
+            } else {
                 await model.uploadFiles(urls: urls)
             }
         }


### PR DESCRIPTION
Code generated by Claude, tested & fix looks _okayish_

- Upload errors were silently cleared by refresh() before the alert could fire; fix by setting self.error after refresh()
- Unreadable local files were skipped silently; now surfaces an error
- Upload loop continued past failures unlike downloads; now breaks early
- Drag-and-drop with no resolvable URLs was silent; now shows an error