### PR TITLE
build: preserve swift build failures in make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ $(BINARY): $(SWIFT_SOURCES) Package.swift $(ENTITLEMENTS)
 	@echo "=== Building vphone-cli ($(GIT_HASH)) ==="
 	@echo '// Auto-generated — do not edit' > $(BUILD_INFO)
 	@echo 'enum VPhoneBuildInfo { static let commitHash = "$(GIT_HASH)" }' >> $(BUILD_INFO)
-	swift build -c release 2>&1 | tail -5
+	@set -o pipefail; swift build -c release 2>&1 | tail -5
 	@echo ""
 	@echo "=== Signing with entitlements ==="
 	codesign --force --sign - --entitlements $(ENTITLEMENTS) $@


### PR DESCRIPTION
## Summary

This PR fixes the `make build` recipe so Swift build failures are not masked by the log-trimming pipeline.

## Problem

The current build target runs:

```sh
swift build -c release 2>&1 | tail -5
```

Because the recipe uses a pipeline without `pipefail`, a failed `swift build` can still be followed by the signing step if `tail` exits successfully. That can leave the build target looking successful while codesigning a stale binary.

## Change

- Run the piped build command under `set -o pipefail`
- Keep the existing `tail -5` output trimming behavior
- Preserve the existing signing flow for successful builds

## Validation

- Verified `set -o pipefail` propagates pipeline failures under the current shell
- Ran `make build` successfully after the change
