### PR TITLE
Support TIPA installs and show success feedback

### DIFF
--- a/sources/vphone-cli/VPhoneInstallPackage.swift
+++ b/sources/vphone-cli/VPhoneInstallPackage.swift
@@ -1,0 +1,29 @@
+import Foundation
+import UniformTypeIdentifiers
+
+enum VPhoneInstallPackage {
+    static let allowedContentTypes: [UTType] = [
+        UTType(filenameExtension: "ipa"),
+        UTType(filenameExtension: "tipa"),
+    ].compactMap { $0 }
+
+    static func isSupportedFile(_ url: URL) -> Bool {
+        switch url.pathExtension.lowercased() {
+        case "ipa", "tipa":
+            true
+        default:
+            false
+        }
+    }
+
+    static func successMessage(for fileName: String, detail: String) -> String {
+        let trimmedDetail = detail.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedDetail.isEmpty else {
+            return "Installed \(fileName)."
+        }
+        if trimmedDetail.localizedCaseInsensitiveContains(fileName) {
+            return trimmedDetail
+        }
+        return "Installed \(fileName).\n\n\(trimmedDetail)"
+    }
+}

--- a/sources/vphone-cli/VPhoneMenuInstall.swift
+++ b/sources/vphone-cli/VPhoneMenuInstall.swift
@@ -1,6 +1,5 @@
 import AppKit
 import Foundation
-import UniformTypeIdentifiers
 
 // MARK: - Install Menu
 
@@ -8,14 +7,14 @@ extension VPhoneMenuController {
     func buildInstallMenu() -> NSMenuItem {
         let item = NSMenuItem()
         let menu = NSMenu(title: "Install")
-        menu.addItem(makeItem("Install IPA...", action: #selector(installIPAFromDisk)))
+        menu.addItem(makeItem("Install IPA/TIPA...", action: #selector(installIPAFromDisk)))
         item.submenu = menu
         return item
     }
 
     @objc func installIPAFromDisk() {
         guard control.isConnected else {
-            showAlert(title: "Install IPA", message: "Guest is not connected.", style: .warning)
+            showAlert(title: "Install App Package", message: "Guest is not connected.", style: .warning)
             return
         }
 
@@ -23,11 +22,9 @@ extension VPhoneMenuController {
         panel.canChooseFiles = true
         panel.canChooseDirectories = false
         panel.allowsMultipleSelection = false
-        panel.allowedContentTypes = [
-            UTType(filenameExtension: "ipa") ?? .data,
-        ]
+        panel.allowedContentTypes = VPhoneInstallPackage.allowedContentTypes
         panel.prompt = "Install"
-        panel.message = "Choose an IPA to install in the guest."
+        panel.message = "Choose an IPA or TIPA package to install in the guest."
 
         let response = panel.runModal()
         guard response == .OK, let url = panel.url else { return }
@@ -36,8 +33,16 @@ extension VPhoneMenuController {
             do {
                 let result = try await control.installIPA(localURL: url)
                 print("[install] \(result)")
+                showAlert(
+                    title: "Install App Package",
+                    message: VPhoneInstallPackage.successMessage(
+                        for: url.lastPathComponent,
+                        detail: result
+                    ),
+                    style: .informational
+                )
             } catch {
-                showAlert(title: "Install IPA", message: "\(error)", style: .warning)
+                showAlert(title: "Install App Package", message: "\(error)", style: .warning)
             }
         }
     }

--- a/sources/vphone-cli/VPhoneVirtualMachineView.swift
+++ b/sources/vphone-cli/VPhoneVirtualMachineView.swift
@@ -88,7 +88,7 @@ class VPhoneVirtualMachineView: VZVirtualMachineView {
     // MARK: - Drag and Drop Install
 
     override func draggingEntered(_ sender: any NSDraggingInfo) -> NSDragOperation {
-        guard droppedIPAURL(from: sender) != nil else { return [] }
+        guard droppedInstallPackageURL(from: sender) != nil else { return [] }
         updateDragHighlight(true)
         return .copy
     }
@@ -99,44 +99,49 @@ class VPhoneVirtualMachineView: VZVirtualMachineView {
     }
 
     override func prepareForDragOperation(_ sender: any NSDraggingInfo) -> Bool {
-        droppedIPAURL(from: sender) != nil
+        droppedInstallPackageURL(from: sender) != nil
     }
 
     override func performDragOperation(_ sender: any NSDraggingInfo) -> Bool {
         updateDragHighlight(false)
-        guard let url = droppedIPAURL(from: sender) else { return false }
+        guard let url = droppedInstallPackageURL(from: sender) else { return false }
 
         Task { @MainActor in
             guard let control else {
-                showAlert(title: "Install IPA", message: "Guest is not connected.", style: .warning)
+                showAlert(title: "Install App Package", message: "Guest is not connected.", style: .warning)
                 return
             }
             guard control.isConnected else {
-                showAlert(title: "Install IPA", message: "Guest is not connected.", style: .warning)
+                showAlert(title: "Install App Package", message: "Guest is not connected.", style: .warning)
                 return
             }
 
             do {
                 let result = try await control.installIPA(localURL: url)
                 print("[install] \(result)")
+                showAlert(
+                    title: "Install App Package",
+                    message: VPhoneInstallPackage.successMessage(
+                        for: url.lastPathComponent,
+                        detail: result
+                    ),
+                    style: .informational
+                )
             } catch {
-                showAlert(title: "Install IPA", message: "\(error)", style: .warning)
+                showAlert(title: "Install App Package", message: "\(error)", style: .warning)
             }
         }
         return true
     }
 
-    private func droppedIPAURL(from sender: any NSDraggingInfo) -> URL? {
+    private func droppedInstallPackageURL(from sender: any NSDraggingInfo) -> URL? {
         let options: [NSPasteboard.ReadingOptionKey: Any] = [
             .urlReadingFileURLsOnly: true,
         ]
         guard let urls = sender.draggingPasteboard.readObjects(forClasses: [NSURL.self], options: options) as? [URL] else {
             return nil
         }
-        return urls.first {
-            let ext = $0.pathExtension.lowercased()
-            return ext == "ipa" || ext == "tipa"
-        }
+        return urls.first(where: VPhoneInstallPackage.isSupportedFile)
     }
 
     private func updateDragHighlight(_ visible: Bool) {


### PR DESCRIPTION
## Summary

This PR makes app package installation more consistent and user-visible in two small ways:

1. The Install menu now accepts both `.ipa` and `.tipa` packages, matching the existing drag-and-drop path.
2. Successful installs now show an informational alert instead of only printing to stdout.

## Changes

- Added a small shared `VPhoneInstallPackage` helper to centralize supported package detection.
- Updated the Install menu open panel to allow both `.ipa` and `.tipa`.
- Updated drag-and-drop package detection to reuse the same shared helper.
- Added visible success alerts for both menu installs and drag-and-drop installs.
- Adjusted install UI copy to reflect IPA/TIPA support.

## Why

Before this change:

- drag-and-drop accepted `.tipa`, but the Install menu did not
- successful installs were only visible in logs, which made the UI feel silent even when installation completed correctly

This keeps the two install entry points aligned and makes success state obvious to the user.

## Validation

- `make build`
