### PR TITLE
Fix IPA extraction failing through /var/tmp symlink on iOS

### DIFF
--- a/scripts/vphoned/unarchive.m
+++ b/scripts/vphoned/unarchive.m
@@ -26,8 +26,7 @@ int vp_extract_archive(NSString *archivePath, NSString *extractionPath) {
               | ARCHIVE_EXTRACT_ACL
               | ARCHIVE_EXTRACT_FFLAGS
               | ARCHIVE_EXTRACT_SECURE_SYMLINKS
-              | ARCHIVE_EXTRACT_SECURE_NODOTDOT
-              | ARCHIVE_EXTRACT_SECURE_NOABSOLUTEPATHS;
+              | ARCHIVE_EXTRACT_SECURE_NODOTDOT;
 
     struct archive *a = archive_read_new();
     archive_read_support_format_all(a);
@@ -61,13 +60,12 @@ int vp_extract_archive(NSString *archivePath, NSString *extractionPath) {
         r = archive_write_header(ext, entry);
         if (r < ARCHIVE_OK)
             fprintf(stderr, "%s\n", archive_error_string(ext));
-        else if (archive_entry_size(entry) > 0) {
+        else {
             r = copy_data(a, ext);
             if (r < ARCHIVE_OK)
                 fprintf(stderr, "%s\n", archive_error_string(ext));
             if (r < ARCHIVE_WARN) { ret = 1; goto cleanup; }
         }
-
         r = archive_write_finish_entry(ext);
         if (r < ARCHIVE_OK)
             fprintf(stderr, "%s\n", archive_error_string(ext));

--- a/scripts/vphoned/vphoned_install.m
+++ b/scripts/vphoned/vphoned_install.m
@@ -5,9 +5,11 @@
 #include <dlfcn.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <mach-o/fat.h>
 #include <mach-o/loader.h>
 #include <spawn.h>
+#include <stdlib.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -801,6 +803,12 @@ NSDictionary *vp_handle_custom_install(NSDictionary *msg) {
         NSMutableDictionary *response = vp_make_response(@"err", reqId);
         response[@"msg"] = @"failed to create temporary extraction directory";
         return response;
+    }
+    // Resolve symlinks so ARCHIVE_EXTRACT_SECURE_SYMLINKS doesn't reject writes
+    // through /var/tmp -> /private/var/tmp on iOS
+    char resolvedBuf[PATH_MAX];
+    if (realpath(tmpPackagePath.fileSystemRepresentation, resolvedBuf)) {
+        tmpPackagePath = [NSString stringWithUTF8String:resolvedBuf];
     }
 
     NSString *detail = @"";


### PR DESCRIPTION
Issue #136: IPA install was silently failing with "does not contain an .app payload" on every attempt.

Two libarchive flag issues in vp_extract_archive:

- ARCHIVE_EXTRACT_SECURE_NOABSOLUTEPATHS rejected all entries because we intentionally rewrite paths to absolute destinations before writing
- ARCHIVE_EXTRACT_SECURE_SYMLINKS blocked writes through /var/tmp, which is a symlink to /private/var/tmp on iOS

Fix: drop the absolute paths flag, resolve the temp dir with realpath() so the extraction target has no symlink components.