### PR TITLE
Always capture the VM window for recording and screenshots

### DIFF
--- a/sources/vphone-cli/VPhoneAppDelegate.swift
+++ b/sources/vphone-cli/VPhoneAppDelegate.swift
@@ -128,6 +128,7 @@ class VPhoneAppDelegate: NSObject, NSApplicationDelegate {
 
             let mc = VPhoneMenuController(keyHelper: keyHelper, control: control)
             mc.vm = vm
+            mc.captureView = wc.captureView
             mc.onFilesPressed = { [weak fileWC, weak control] in
                 guard let fileWC, let control else { return }
                 fileWC.showWindow(control: control)

--- a/sources/vphone-cli/VPhoneMenuController.swift
+++ b/sources/vphone-cli/VPhoneMenuController.swift
@@ -17,6 +17,7 @@ class VPhoneMenuController {
     var locationReplayStopItem: NSMenuItem?
     var screenRecorder: VPhoneScreenRecorder?
     var recordingItem: NSMenuItem?
+    weak var captureView: VPhoneVirtualMachineView?
 
     init(keyHelper: VPhoneKeyHelper, control: VPhoneControl) {
         self.keyHelper = keyHelper

--- a/sources/vphone-cli/VPhoneMenuRecord.swift
+++ b/sources/vphone-cli/VPhoneMenuRecord.swift
@@ -71,6 +71,7 @@ extension VPhoneMenuController {
     }
 
     private func activeCaptureView() -> NSView? {
-        NSApp.keyWindow?.contentView ?? NSApp.mainWindow?.contentView
+        guard let captureView else { return nil }
+        return captureView.window == nil ? nil : captureView
     }
 }

--- a/sources/vphone-cli/VPhoneWindowController.swift
+++ b/sources/vphone-cli/VPhoneWindowController.swift
@@ -7,8 +7,13 @@ class VPhoneWindowController: NSObject, NSToolbarDelegate {
     private var windowController: NSWindowController?
     private var statusTimer: Timer?
     private weak var control: VPhoneControl?
+    private weak var virtualMachineView: VPhoneVirtualMachineView?
 
     private nonisolated static let homeItemID = NSToolbarItem.Identifier("home")
+
+    var captureView: VPhoneVirtualMachineView? {
+        virtualMachineView
+    }
 
     func showWindow(
         for vm: VZVirtualMachine, screenWidth: Int, screenHeight: Int, screenScale: Double,
@@ -21,6 +26,7 @@ class VPhoneWindowController: NSObject, NSToolbarDelegate {
         view.capturesSystemKeys = true
         view.keyHelper = keyHelper
         view.control = control
+        virtualMachineView = view
         let vmView: NSView = view
 
         let scale = CGFloat(screenScale)


### PR DESCRIPTION
## Summary

This PR fixes recording and screenshot actions so they always capture the actual VM window instead of whichever window currently has focus.

## Problem

The Record menu currently resolves its capture target from:

- `NSApp.keyWindow?.contentView`
- `NSApp.mainWindow?.contentView`

That means auxiliary windows such as the Files window, or even an open/save panel, can steal the capture target away from the VM view. In that state, recording and screenshot actions can fail with "No active VM window" or try to capture the wrong view.

## Changes

- Expose the VM `VPhoneVirtualMachineView` from `VPhoneWindowController`
- Store that explicit capture view reference on `VPhoneMenuController`
- Wire the menu controller to the VM view during app setup
- Update the Record menu to use the explicit VM view instead of key-window lookup

## Why this is better

This keeps recording and screenshots tied to the actual virtual machine display, regardless of which auxiliary window currently has focus.

## Validation

- `make build`
