### PR TITLE
Gate Connect menu actions on guest connection state

### DIFF
--- a/sources/vphone-cli/VPhoneAppDelegate.swift
+++ b/sources/vphone-cli/VPhoneAppDelegate.swift
@@ -141,6 +141,7 @@ class VPhoneAppDelegate: NSObject, NSApplicationDelegate {
 
             // Wire location toggle through onConnect/onDisconnect
             control.onConnect = { [weak mc, weak provider = locationProvider] caps in
+                mc?.updateConnectAvailability(available: true)
                 if caps.contains("location") {
                     mc?.updateLocationCapability(available: true)
                     // Auto-resume if user had toggle on
@@ -152,6 +153,7 @@ class VPhoneAppDelegate: NSObject, NSApplicationDelegate {
                 }
             }
             control.onDisconnect = { [weak mc, weak provider = locationProvider] in
+                mc?.updateConnectAvailability(available: false)
                 provider?.stopReplay()
                 provider?.stopForwarding()
                 mc?.updateLocationCapability(available: false)

--- a/sources/vphone-cli/VPhoneMenuConnect.swift
+++ b/sources/vphone-cli/VPhoneMenuConnect.swift
@@ -6,14 +6,40 @@ extension VPhoneMenuController {
     func buildConnectMenu() -> NSMenuItem {
         let item = NSMenuItem()
         let menu = NSMenu(title: "Connect")
-        menu.addItem(makeItem("File Browser", action: #selector(openFiles)))
+
+        let fileBrowser = makeItem("File Browser", action: #selector(openFiles))
+        fileBrowser.isEnabled = false
+        connectFileBrowserItem = fileBrowser
+        menu.addItem(fileBrowser)
+
         menu.addItem(NSMenuItem.separator())
-        menu.addItem(makeItem("Developer Mode Status", action: #selector(devModeStatus)))
+
+        let devModeStatus = makeItem("Developer Mode Status", action: #selector(devModeStatus))
+        devModeStatus.isEnabled = false
+        connectDevModeStatusItem = devModeStatus
+        menu.addItem(devModeStatus)
+
         menu.addItem(NSMenuItem.separator())
-        menu.addItem(makeItem("Ping", action: #selector(sendPing)))
-        menu.addItem(makeItem("Guest Version", action: #selector(queryGuestVersion)))
+
+        let ping = makeItem("Ping", action: #selector(sendPing))
+        ping.isEnabled = false
+        connectPingItem = ping
+        menu.addItem(ping)
+
+        let guestVersion = makeItem("Guest Version", action: #selector(queryGuestVersion))
+        guestVersion.isEnabled = false
+        connectGuestVersionItem = guestVersion
+        menu.addItem(guestVersion)
+
         item.submenu = menu
         return item
+    }
+
+    func updateConnectAvailability(available: Bool) {
+        connectFileBrowserItem?.isEnabled = available
+        connectDevModeStatusItem?.isEnabled = available
+        connectPingItem?.isEnabled = available
+        connectGuestVersionItem?.isEnabled = available
     }
 
     @objc func openFiles() {

--- a/sources/vphone-cli/VPhoneMenuController.swift
+++ b/sources/vphone-cli/VPhoneMenuController.swift
@@ -10,6 +10,10 @@ class VPhoneMenuController {
     weak var vm: VPhoneVirtualMachine?
 
     var onFilesPressed: (() -> Void)?
+    var connectFileBrowserItem: NSMenuItem?
+    var connectDevModeStatusItem: NSMenuItem?
+    var connectPingItem: NSMenuItem?
+    var connectGuestVersionItem: NSMenuItem?
     var locationProvider: VPhoneLocationProvider?
     var locationMenuItem: NSMenuItem?
     var locationPresetMenuItem: NSMenuItem?


### PR DESCRIPTION
## Summary

This PR makes the `Connect` menu follow the actual guest connection state instead of leaving its actions enabled all the time.

## Problem

The `Connect` menu actions are currently always clickable, even when the guest control channel is not connected yet.

That means users can trigger:

- File Browser
- Developer Mode Status
- Ping
- Guest Version

before the guest is actually ready, and only learn about the problem after an error alert.

## Changes

- Add explicit references for `Connect` menu items in `VPhoneMenuController`
- Disable `Connect` actions by default when the menu is built
- Add `updateConnectAvailability(available:)` to manage the whole group consistently
- Wire the new availability update through existing `onConnect` / `onDisconnect` callbacks in `VPhoneAppDelegate`

## Why this is better

This matches the behavior already used by the `Location` menu:

- unavailable actions are visibly disabled
- the menu reflects actual guest readiness
- users do not have to probe menu items just to discover the control channel is offline

## Validation

- `make build`
