### PR TITLE
Fix TrollStore Lite install failure handling

### DIFF
--- a/scripts/vphone_jb_setup.sh
+++ b/scripts/vphone_jb_setup.sh
@@ -186,8 +186,16 @@ if dpkg -s com.opa334.trollstorelite >/dev/null 2>&1; then
     log "  TrollStore Lite already installed"
 else
     apt-get -o APT::Get::AllowUnauthenticated=true \
-        install -y -qq com.opa334.trollstorelite 2>&1 || log "  TrollStore install exited with $?"
-    log "  TrollStore Lite installed"
+        install -y -qq com.opa334.trollstorelite 2>&1
+    trollstore_rc=$?
+    if [ "$trollstore_rc" -ne 0 ]; then
+        die "TrollStore Lite apt install failed with exit code $trollstore_rc"
+    fi
+    if dpkg -s com.opa334.trollstorelite >/dev/null 2>&1; then
+        log "  TrollStore Lite installed"
+    else
+        die "TrollStore Lite install completed without registering package"
+    fi
 fi
 
 uicache -a 2>/dev/null || true


### PR DESCRIPTION
## Summary
- Stop silently swallowing TrollStore Lite apt install failures — now calls `die` on non-zero exit code
- Add post-install verification via `dpkg -s` to catch cases where apt returns 0 but the package isn't actually registered
