### PR TITLE
Gate Install menu action on guest connection state

### DIFF
--- a/sources/vphone-cli/VPhoneAppDelegate.swift
+++ b/sources/vphone-cli/VPhoneAppDelegate.swift
@@ -150,6 +150,7 @@ class VPhoneAppDelegate: NSObject, NSApplicationDelegate {
             // Wire location toggle through onConnect/onDisconnect
             control.onConnect = { [weak mc, weak provider = locationProvider] caps in
                 mc?.updateConnectAvailability(available: true)
+                mc?.updateInstallAvailability(available: true)
                 if caps.contains("location") {
                     mc?.updateLocationCapability(available: true)
                     // Auto-resume if user had toggle on
@@ -162,6 +163,7 @@ class VPhoneAppDelegate: NSObject, NSApplicationDelegate {
             }
             control.onDisconnect = { [weak mc, weak provider = locationProvider] in
                 mc?.updateConnectAvailability(available: false)
+                mc?.updateInstallAvailability(available: false)
                 provider?.stopReplay()
                 provider?.stopForwarding()
                 mc?.updateLocationCapability(available: false)

--- a/sources/vphone-cli/VPhoneMenuController.swift
+++ b/sources/vphone-cli/VPhoneMenuController.swift
@@ -16,6 +16,7 @@ class VPhoneMenuController {
     var connectDevModeStatusItem: NSMenuItem?
     var connectPingItem: NSMenuItem?
     var connectGuestVersionItem: NSMenuItem?
+    var installPackageItem: NSMenuItem?
     var locationProvider: VPhoneLocationProvider?
     var locationMenuItem: NSMenuItem?
     var locationPresetMenuItem: NSMenuItem?

--- a/sources/vphone-cli/VPhoneMenuInstall.swift
+++ b/sources/vphone-cli/VPhoneMenuInstall.swift
@@ -7,9 +7,18 @@ extension VPhoneMenuController {
     func buildInstallMenu() -> NSMenuItem {
         let item = NSMenuItem()
         let menu = NSMenu(title: "Install")
-        menu.addItem(makeItem("Install IPA/TIPA...", action: #selector(installIPAFromDisk)))
+        menu.autoenablesItems = false
+
+        let install = makeItem("Install IPA/TIPA...", action: #selector(installIPAFromDisk))
+        install.isEnabled = false
+        installPackageItem = install
+        menu.addItem(install)
         item.submenu = menu
         return item
+    }
+
+    func updateInstallAvailability(available: Bool) {
+        installPackageItem?.isEnabled = available
     }
 
     @objc func installIPAFromDisk() {


### PR DESCRIPTION
## Summary
- disable the Install menu action until the guest connection is ready
- reuse the existing menu/controller connection lifecycle to toggle Install availability
- keep the existing warning path as a defensive fallback if the action is triggered without a connection

## Validation
- make build