### PR TITLE
Fix vphoned build failure in cfw_install.sh — missing source files

### DIFF
--- a/scripts/cfw_install.sh
+++ b/scripts/cfw_install.sh
@@ -434,17 +434,7 @@ echo "[7/7] Installing LaunchDaemons..."
 # Install vphoned (vsock HID injector daemon)
 VPHONED_SRC="$SCRIPT_DIR/vphoned"
 VPHONED_BIN="$VPHONED_SRC/vphoned"
-VPHONED_SRCS=(
-    "$VPHONED_SRC/unarchive.m"
-    "$VPHONED_SRC/vphoned.m"
-    "$VPHONED_SRC/vphoned_install.m"
-    "$VPHONED_SRC/vphoned_protocol.m"
-    "$VPHONED_SRC/vphoned_hid.m"
-    "$VPHONED_SRC/vphoned_devmode.m"
-    "$VPHONED_SRC/vphoned_location.m"
-    "$VPHONED_SRC/vphoned_files.m"
-    "$VPHONED_SRC/vphoned_keychain.m"
-)
+VPHONED_SRCS=("$VPHONED_SRC"/*.m)
 needs_vphoned_build=0
 if [[ ! -f "$VPHONED_BIN" ]]; then
     needs_vphoned_build=1


### PR DESCRIPTION
Fixes #184

## Problem

Running `make setup_machine JB=1` (or just `make cfw_install`) on a fresh clone fails at `[7/7] Installing LaunchDaemons...` with undefined symbols:

```
Undefined symbols for architecture arm64:
  "_vp_apps_load", "_vp_clipboard_load", "_vp_handle_accessibility_command",
  "_vp_handle_apps_command", "_vp_handle_clipboard_command",
  "_vp_handle_settings_command", "_vp_handle_url_command"
```

## What happened

Commit `e189b80` added several new vphoned modules (`vphoned_apps.m`, `vphoned_clipboard.m`, `vphoned_accessibility.m`, `vphoned_settings.m`, `vphoned_url.m`) and updated `vphoned.m` to import and call into them. However, `scripts/cfw_install.sh` still has a hardcoded list of 9 source files in `VPHONED_SRCS` that doesn't include the new modules.

The `scripts/vphoned/Makefile` doesn't have this problem because it uses `$(wildcard *.m)`.

So there are two build paths that disagree:

| Build path | Source selection | Works? |
|---|---|---|
| `scripts/vphoned/Makefile` | `$(wildcard *.m)` | yes |
| `scripts/cfw_install.sh` | hardcoded list of 9 files | no |

Since `cfw_install_jb.sh` and `cfw_install_dev.sh` both call `cfw_install.sh` first, all three variants are broken.

## Fix

Replace the hardcoded source list with a glob, matching what the Makefile already does:

```sh
VPHONED_SRCS=("$VPHONED_SRC"/*.m)
```

This way future modules are picked up automatically without needing to touch the script again.
