### PR TITLE
Gate Open URL on the guest url capability

### DIFF
--- a/sources/vphone-cli/VPhoneAppDelegate.swift
+++ b/sources/vphone-cli/VPhoneAppDelegate.swift
@@ -139,6 +139,7 @@ class VPhoneAppDelegate: NSObject, NSApplicationDelegate {
                 mc?.updateConnectAvailability(available: true)
                 mc?.updateInstallAvailability(available: true)
                 mc?.updateAppsAvailability(available: caps.contains("apps"))
+                mc?.updateURLAvailability(available: caps.contains("url"))
                 mc?.updateClipboardAvailability(available: caps.contains("clipboard"))
                 mc?.updateSettingsAvailability(available: true)
                 if caps.contains("location") {
@@ -155,6 +156,7 @@ class VPhoneAppDelegate: NSObject, NSApplicationDelegate {
                 mc?.updateConnectAvailability(available: false)
                 mc?.updateInstallAvailability(available: false)
                 mc?.updateAppsAvailability(available: false)
+                mc?.updateURLAvailability(available: false)
                 mc?.updateClipboardAvailability(available: false)
                 mc?.updateSettingsAvailability(available: false)
                 provider?.stopReplay()

--- a/sources/vphone-cli/VPhoneMenuApps.swift
+++ b/sources/vphone-cli/VPhoneMenuApps.swift
@@ -34,6 +34,9 @@ extension VPhoneMenuController {
 
     func updateAppsAvailability(available: Bool) {
         appsListItem?.isEnabled = available
+    }
+
+    func updateURLAvailability(available: Bool) {
         appsOpenURLItem?.isEnabled = available
     }
 


### PR DESCRIPTION
## Summary
- split Apps menu gating so App Browser still follows the `apps` capability
- enable `Open URL...` based on the guest `url` capability instead of tying it to `apps`
- keep disconnect behavior unchanged by disabling both actions when the guest disconnects

## Validation
- make build