### PR TITLE
fix: prefer project venv Python for patchers

### DIFF
--- a/scripts/cfw_install.sh
+++ b/scripts/cfw_install.sh
@@ -24,6 +24,22 @@ CFW_SKIP_HALT="${CFW_SKIP_HALT:-0}"
 # Resolve absolute paths
 VM_DIR="$(cd "$VM_DIR" && pwd)"
 
+# ── Python resolver — prefer project venv over whatever is in PATH ─
+# Resolves to .venv/bin/python3 relative to the project root (parent of
+# scripts/), falling back to the system python3 when the venv is absent.
+# Every python3 invocation in this script uses $PYTHON3 so that running
+# `make cfw_install` standalone (without setup_machine.sh exporting PATH)
+# still uses the correctly set-up venv interpreter.
+_resolve_python3() {
+    local venv_py="${SCRIPT_DIR:h}/.venv/bin/python3"
+    if [[ -x "$venv_py" ]]; then
+        echo "$venv_py"
+    else
+        command -v python3 || true
+    fi
+}
+PYTHON3="$(_resolve_python3)"
+
 # ── Configuration ───────────────────────────────────────────────
 CFW_INPUT="cfw_input"
 CFW_ARCHIVE="cfw_input.tar.zst"
@@ -191,9 +207,12 @@ setup_cfw_input() {
 check_prereqs() {
     command -v ipsw >/dev/null 2>&1 || die "'ipsw' not found. Install: brew install blacktop/tap/ipsw"
     command -v aea >/dev/null 2>&1 || die "'aea' not found (requires macOS 12+)"
-    command -v python3 >/dev/null 2>&1 || die "python3 not found"
-    python3 -c "import capstone, keystone" 2>/dev/null ||
-        die "Missing Python deps. Install: pip install capstone keystone-engine"
+    [[ -x "$PYTHON3" ]] || die "python3 not found (tried: $PYTHON3). Run: make setup_venv"
+    echo "[*] Python: $PYTHON3 ($("$PYTHON3" --version 2>&1))"
+    local py_err
+    py_err="$("$PYTHON3" -c "import capstone, keystone" 2>&1)" || {
+        die "Missing Python deps (using $PYTHON3).\n  Error: ${py_err}\n  Fix:   source ${SCRIPT_DIR:h}/.venv/bin/activate && pip install capstone keystone-engine\n  Or:    make setup_venv"
+    }
 }
 
 # ── Cleanup trap (unmount DMGs on error) ───────────────────────
@@ -224,7 +243,7 @@ mkdir -p "$TEMP_DIR"
 # ── Parse Cryptex paths from BuildManifest ─────────────────────
 echo ""
 echo "[*] Parsing iPhone BuildManifest for Cryptex paths..."
-CRYPTEX_PATHS=$(python3 "$SCRIPT_DIR/patchers/cfw.py" cryptex-paths "$RESTORE_DIR/BuildManifest-iPhone.plist")
+CRYPTEX_PATHS=$("$PYTHON3" "$SCRIPT_DIR/patchers/cfw.py" cryptex-paths "$RESTORE_DIR/BuildManifest-iPhone.plist")
 CRYPTEX_SYSOS=$(echo "$CRYPTEX_PATHS" | head -1)
 CRYPTEX_APPOS=$(echo "$CRYPTEX_PATHS" | tail -1)
 echo "  SystemOS: $CRYPTEX_SYSOS"
@@ -346,7 +365,7 @@ if ! remote_file_exists "/mnt1/usr/libexec/seputil.bak"; then
 fi
 
 scp_from "/mnt1/usr/libexec/seputil.bak" "$TEMP_DIR/seputil"
-python3 "$SCRIPT_DIR/patchers/cfw.py" patch-seputil "$TEMP_DIR/seputil"
+"$PYTHON3" "$SCRIPT_DIR/patchers/cfw.py" patch-seputil "$TEMP_DIR/seputil"
 ldid_sign "$TEMP_DIR/seputil" "com.apple.seputil"
 scp_to "$TEMP_DIR/seputil" "/mnt1/usr/libexec/seputil"
 ssh_cmd "/bin/chmod 0755 /mnt1/usr/libexec/seputil"
@@ -402,7 +421,7 @@ if ! remote_file_exists "/mnt1/usr/libexec/launchd_cache_loader.bak"; then
 fi
 
 scp_from "/mnt1/usr/libexec/launchd_cache_loader.bak" "$TEMP_DIR/launchd_cache_loader"
-python3 "$SCRIPT_DIR/patchers/cfw.py" patch-launchd-cache-loader "$TEMP_DIR/launchd_cache_loader"
+"$PYTHON3" "$SCRIPT_DIR/patchers/cfw.py" patch-launchd-cache-loader "$TEMP_DIR/launchd_cache_loader"
 ldid_sign "$TEMP_DIR/launchd_cache_loader" "com.apple.launchd_cache_loader"
 scp_to "$TEMP_DIR/launchd_cache_loader" "/mnt1/usr/libexec/launchd_cache_loader"
 ssh_cmd "/bin/chmod 0755 /mnt1/usr/libexec/launchd_cache_loader"
@@ -420,7 +439,7 @@ if ! remote_file_exists "/mnt1/usr/libexec/mobileactivationd.bak"; then
 fi
 
 scp_from "/mnt1/usr/libexec/mobileactivationd.bak" "$TEMP_DIR/mobileactivationd"
-python3 "$SCRIPT_DIR/patchers/cfw.py" patch-mobileactivationd "$TEMP_DIR/mobileactivationd"
+"$PYTHON3" "$SCRIPT_DIR/patchers/cfw.py" patch-mobileactivationd "$TEMP_DIR/mobileactivationd"
 ldid_sign "$TEMP_DIR/mobileactivationd"
 scp_to "$TEMP_DIR/mobileactivationd" "/mnt1/usr/libexec/mobileactivationd"
 ssh_cmd "/bin/chmod 0755 /mnt1/usr/libexec/mobileactivationd"
@@ -496,7 +515,7 @@ fi
 
 scp_from "/mnt1/System/Library/xpc/launchd.plist.bak" "$TEMP_DIR/launchd.plist"
 cp "$VPHONED_SRC/vphoned.plist" "$INPUT_DIR/jb/LaunchDaemons/"
-python3 "$SCRIPT_DIR/patchers/cfw.py" inject-daemons "$TEMP_DIR/launchd.plist" "$INPUT_DIR/jb/LaunchDaemons"
+"$PYTHON3" "$SCRIPT_DIR/patchers/cfw.py" inject-daemons "$TEMP_DIR/launchd.plist" "$INPUT_DIR/jb/LaunchDaemons"
 scp_to "$TEMP_DIR/launchd.plist" "/mnt1/System/Library/xpc/launchd.plist"
 ssh_cmd "/bin/chmod 0644 /mnt1/System/Library/xpc/launchd.plist"
 

--- a/scripts/cfw_install_jb.sh
+++ b/scripts/cfw_install_jb.sh
@@ -15,6 +15,19 @@ set -euo pipefail
 VM_DIR="${1:-.}"
 SCRIPT_DIR="${0:a:h}"
 
+# ── Python resolver — prefer project venv over whatever is in PATH ─
+# Resolves to .venv/bin/python3 relative to the project root (parent of
+# scripts/), falling back to the system python3 when the venv is absent.
+_resolve_python3() {
+    local venv_py="${SCRIPT_DIR:h}/.venv/bin/python3"
+    if [[ -x "$venv_py" ]]; then
+        echo "$venv_py"
+    else
+        command -v python3 || true
+    fi
+}
+PYTHON3="$(_resolve_python3)"
+
 # ════════════════════════════════════════════════════════════════
 # Step 1: Run base CFW install (skip halt — we continue with JB phases)
 # ════════════════════════════════════════════════════════════════
@@ -225,10 +238,10 @@ fi
 # LC_LOAD_DYLIB command after stripping LC_CODE_SIGNATURE.
 if [[ -d "$JB_INPUT_DIR/basebin" ]]; then
     echo "  Injecting LC_LOAD_DYLIB for /b (short launchdhook alias)..."
-    python3 "$SCRIPT_DIR/patchers/cfw.py" inject-dylib "$TEMP_DIR/launchd" "/b"
+    "$PYTHON3" "$SCRIPT_DIR/patchers/cfw.py" inject-dylib "$TEMP_DIR/launchd" "/b"
 fi
 
-python3 "$SCRIPT_DIR/patchers/cfw.py" patch-launchd-jetsam "$TEMP_DIR/launchd"
+"$PYTHON3" "$SCRIPT_DIR/patchers/cfw.py" patch-launchd-jetsam "$TEMP_DIR/launchd"
 
 # Re-sign with original entitlements to avoid "operation not permitted" on spawn
 if [[ -s "$TEMP_DIR/launchd.entitlements" ]]; then
@@ -375,7 +388,7 @@ if [[ -f "$SETUP_PLIST" ]]; then
     # Inject into launchd.plist so launchd starts it at boot
     echo "  Injecting com.vphone.jb-setup into launchd.plist..."
     scp_from "/mnt1/System/Library/xpc/launchd.plist" "$TEMP_DIR/launchd.plist"
-    python3 -c "
+    "$PYTHON3" -c "
 import plistlib, sys
 with open(sys.argv[1], 'rb') as f:
     target = plistlib.load(f)

--- a/scripts/setup_machine.sh
+++ b/scripts/setup_machine.sh
@@ -414,6 +414,30 @@ stop_process_tree() {
   wait "$pid" 2>/dev/null || true
 }
 
+kill_stale_vphone_procs() {
+  local vphone_bin="${PROJECT_ROOT}/.build/release/vphone-cli"
+  local -a stale_pids
+  stale_pids=(${(@f)$(pgrep -f "$vphone_bin" 2>/dev/null || true)})
+  (( ${#stale_pids[@]} == 0 )) && return
+
+  echo "[*] Found stale vphone-cli process(es) (pids: ${stale_pids[*]}); terminating..."
+  for pid in "${stale_pids[@]}"; do
+    [[ "$pid" == "$$" ]] && continue
+    stop_process_tree "$pid"
+  done
+
+  # Wait up to 8s for VZ file locks to clear (flock/fcntl locks may lag behind process exit)
+  local waited=0
+  while (( waited < 8 )); do
+    local -a remaining
+    remaining=(${(@f)$(collect_vm_lock_pids)})
+    (( ${#remaining[@]} == 0 )) && break
+    sleep 1
+    (( waited++ ))
+  done
+  echo "[+] Stale vphone-cli processes cleared"
+}
+
 force_release_vm_locks() {
   local -a lock_pids
   local pid
@@ -706,6 +730,7 @@ start_boot_dfu() {
     return
   fi
 
+  kill_stale_vphone_procs
   check_vm_storage_locks
 
   : > "$DFU_LOG"
@@ -971,6 +996,10 @@ main() {
     run_make "Project setup" setup_tools
     run_make "Project setup" build
   fi
+
+  # Activate venv so all child scripts (cfw_install, patchers, etc.) use the
+  # project Python with capstone/keystone/pyimg4 installed, not the bare system python3.
+  export PATH="$PROJECT_ROOT/.venv/bin:$PATH"
 
   run_make "Firmware prep" vm_new
   run_make "Firmware prep" fw_prepare

--- a/scripts/vm_manifest.py
+++ b/scripts/vm_manifest.py
@@ -4,6 +4,7 @@ vm_manifest.py — Generate VM manifest plist for vphone-cli.
 
 Compatible with security-pcc's VMBundle.Config format.
 """
+
 import argparse
 import plistlib
 import sys
@@ -58,7 +59,7 @@ def create_manifest(
         },
         "sepStorage": "SEPStorage",
     }
-    
+
     if platform_fusing is not None:
         manifest["platformFusing"] = platform_fusing
 


### PR DESCRIPTION
Scripts that invoke Python patchers (`cfw_install.sh`, `cfw_install_jb.sh`) previously relied on whatever `python3` was found in `PATH`, which could be a bare system interpreter missing `capstone`, `keystone-engine`, and `pyimg4`.

This fix introduces a `_resolve_python3()` helper in both install scripts that resolves to `.venv/bin/python3` relative to the project root when the venv exists, falling back to system `python3` only if it doesn't. All `python3` invocations in those scripts now use the resolved `$PYTHON3` variable.

`setup_machine.sh` is also updated to prepend `.venv/bin` to `PATH` before running any make targets, so child scripts inherit the correct interpreter automatically. Additionally, a `kill_stale_vphone_procs` helper is added to clean up leftover `vphone-cli` processes before a DFU boot attempt.