### PR TITLE
Gate Install on the guest ipa_install capability

### DIFF
--- a/sources/vphone-cli/VPhoneAppDelegate.swift
+++ b/sources/vphone-cli/VPhoneAppDelegate.swift
@@ -137,7 +137,7 @@ class VPhoneAppDelegate: NSObject, NSApplicationDelegate {
             // Wire location toggle through onConnect/onDisconnect
             control.onConnect = { [weak mc, weak provider = locationProvider] caps in
                 mc?.updateConnectAvailability(available: true)
-                mc?.updateInstallAvailability(available: true)
+                mc?.updateInstallAvailability(available: caps.contains("ipa_install"))
                 mc?.updateAppsAvailability(available: caps.contains("apps"))
                 mc?.updateURLAvailability(available: caps.contains("url"))
                 mc?.updateClipboardAvailability(available: caps.contains("clipboard"))


### PR DESCRIPTION
## Summary
- gate `Install IPA/TIPA...` based on the guest `ipa_install` capability
- keep the existing disconnect behavior unchanged (install remains disabled when disconnected)
- align host menu availability with vphoned capability advertisement

## Validation
- make build