### PR TITLE
setup_machine: Fix `(( waited++ ))` causing exit on first iteration

### DIFF
--- a/scripts/setup_machine.sh
+++ b/scripts/setup_machine.sh
@@ -89,7 +89,7 @@ load_device_identity() {
       break
     fi
     sleep 1
-    (( waited++ ))
+    (( ++waited ))
   done
 
   [[ -f "$prediction_file" ]] || die "Missing ${prediction_file}. Rebuild and run make boot_dfu to generate it."


### PR DESCRIPTION
In the first iteration, waited would be 0 and cause the expression to be evaluated to `(( 0 ))`, which exists as it returns 1.