### PR TITLE
Refresh App Browser on reconnect and clear stale errors

### DIFF
--- a/sources/vphone-cli/VPhoneAppBrowserModel.swift
+++ b/sources/vphone-cli/VPhoneAppBrowserModel.swift
@@ -36,6 +36,7 @@ class VPhoneAppBrowserModel {
         defer { isLoading = false }
         do {
             apps = try await control.appList(filter: filter.rawValue)
+            error = nil
         } catch {
             self.error = "\(error)"
         }

--- a/sources/vphone-cli/VPhoneAppBrowserView.swift
+++ b/sources/vphone-cli/VPhoneAppBrowserView.swift
@@ -22,6 +22,11 @@ struct VPhoneAppBrowserView: View {
         }
         .searchable(text: $model.searchText, prompt: "Filter by name or bundle ID")
         .task { await model.refresh() }
+        .onChange(of: model.control.isConnected) { _, connected in
+            if connected {
+                Task { await model.refresh() }
+            }
+        }
         .alert(
             "Error",
             isPresented: .init(


### PR DESCRIPTION
## Summary

This PR tightens App Browser refresh behavior in two small ways:

1. Automatically refresh the app list when the guest reconnects
2. Clear stale error state after a successful refresh

## Why

The App Browser currently only refreshes on first load and when the filter changes. If the guest disconnects and reconnects while the window stays open, the view can keep showing stale app data until the user manually refreshes.

It can also keep showing an old error alert even after a later refresh succeeds.

## Changes

- Added a reconnect listener in `VPhoneAppBrowserView`
  - When `control.isConnected` flips back to `true`, the view triggers `refresh()` automatically
- Updated `VPhoneAppBrowserModel.refresh()`
  - Clears `error` after a successful `appList(...)` call

## Scope

- No protocol changes
- No guest-side changes
- No App Browser UI redesign

## Validation

- `make build`
