### PR TITLE
setup_machine: avoid errexit-sensitive arithmetic increments

### DIFF
--- a/scripts/setup_machine.sh
+++ b/scripts/setup_machine.sh
@@ -89,7 +89,7 @@ load_device_identity() {
       break
     fi
     sleep 1
-    (( ++waited ))
+    waited=$(( waited + 1 ))
   done
 
   [[ -f "$prediction_file" ]] || die "Missing ${prediction_file}. Rebuild and run make boot_dfu to generate it."
@@ -433,7 +433,7 @@ kill_stale_vphone_procs() {
     remaining=(${(@f)$(collect_vm_lock_pids)})
     (( ${#remaining[@]} == 0 )) && break
     sleep 1
-    (( waited++ ))
+    waited=$(( waited + 1 ))
   done
   echo "[+] Stale vphone-cli processes cleared"
 }
@@ -545,7 +545,7 @@ monitor_boot_log_until() {
       return 0
     fi
     sleep 1
-    (( ++waited ))
+    waited=$(( waited + 1 ))
   done
 
   echo "timeout"
@@ -772,7 +772,7 @@ wait_for_post_restore_reboot() {
       return
     fi
     sleep 1
-    (( remaining-- ))
+    remaining=$(( remaining - 1 ))
   done
 
   if (( panic_seen == 1 )); then


### PR DESCRIPTION
## Summary

`setup_machine.sh` runs with `set -euo pipefail`, but still used arithmetic increment/decrement forms that can return status `1` in zsh and trigger an early exit.

This PR replaces those forms with assignment-based arithmetic updates.

## Changes

- Replaced `(( ++waited ))` with `waited=$(( waited + 1 ))`
- Replaced `(( waited++ ))` with `waited=$(( waited + 1 ))`
- Replaced `(( remaining-- ))` with `remaining=$(( remaining - 1 ))`

Updated call sites:
- `load_device_identity`
- `kill_stale_vphone_procs`
- `monitor_boot_log_until`
- `wait_for_post_restore_reboot`

## Why

With `set -e`, arithmetic commands can terminate the script based on expression result, not only on actual runtime errors. Assignment-based arithmetic keeps the same behavior while returning a stable success status.

## Validation

- `zsh -n scripts/setup_machine.sh`
- local repro of the shell behavior:
  - `zsh -c 'set -e; i=0; (( i++ )); echo after'` exits before `echo`
