### PR TITLE
control: gate accessibility_tree on guest capability

### DIFF
--- a/sources/vphone-cli/VPhoneControl.swift
+++ b/sources/vphone-cli/VPhoneControl.swift
@@ -78,6 +78,7 @@ class VPhoneControl {
 
     enum ControlError: Error, CustomStringConvertible {
         case notConnected
+        case unsupportedCapability(String)
         case cancelled(String)
         case requestTimedOut(type: String, seconds: Int)
         case protocolError(String)
@@ -86,6 +87,8 @@ class VPhoneControl {
         var description: String {
             switch self {
             case .notConnected: "not connected to vphoned"
+            case let .unsupportedCapability(capability):
+                "guest does not support capability: \(capability)"
             case let .cancelled(reason): "request cancelled: \(reason)"
             case let .requestTimedOut(type, seconds):
                 "request timed out (\(type), \(seconds)s)"
@@ -652,6 +655,9 @@ class VPhoneControl {
     // MARK: - Accessibility
 
     func accessibilityTree(depth: Int = -1) async throws -> [String: Any] {
+        guard guestCaps.contains("accessibility_tree") else {
+            throw ControlError.unsupportedCapability("accessibility_tree")
+        }
         let (resp, _) = try await sendRequest(["t": "accessibility_tree", "depth": depth])
         return resp
     }


### PR DESCRIPTION
## Summary

This PR aligns `accessibility_tree` behavior with capability negotiation.

If the guest does not advertise `accessibility_tree`, host-side calls now fail fast with a clear capability error instead of sending a request that is known to be unsupported.

## Why

`vphoned` currently handles `accessibility_tree` through a stub path and does not advertise it in hello capabilities.

Without host-side gating, callers still send the request and only discover this after round-tripping to the guest. Capability-based fail-fast behavior is clearer and consistent with the rest of the control surface.

## Changes

- Added `ControlError.unsupportedCapability(String)`
- Added a guard in `VPhoneControl.accessibilityTree(depth:)`:
  - requires `guestCaps.contains("accessibility_tree")`
  - otherwise throws `unsupportedCapability("accessibility_tree")`

## Scope

- Host-side only (`VPhoneControl`)
- No protocol changes
- No guest daemon behavior changes

## Validation

- `make build`
