### PR TITLE
vm: validate restore and switch backup names

### DIFF
--- a/scripts/vm_restore.sh
+++ b/scripts/vm_restore.sh
@@ -11,6 +11,15 @@ BACKUPS_DIR="${BACKUPS_DIR:-vm.backups}"
 NAME="${NAME:-}"
 FORCE="${FORCE:-0}"
 
+validate_backup_name() {
+    local name="$1"
+    local label="${2:-NAME}"
+    if [[ "$name" == */* || "$name" == .* ]]; then
+        echo "ERROR: ${label} must be a simple identifier (no slashes or leading dots)."
+        exit 1
+    fi
+}
+
 # --- Parse args ---
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -38,6 +47,8 @@ if [[ -z "${NAME}" ]]; then
     fi
     exit 1
 fi
+
+validate_backup_name "${NAME}"
 
 SRC="${BACKUPS_DIR}/${NAME}"
 

--- a/scripts/vm_switch.sh
+++ b/scripts/vm_switch.sh
@@ -13,6 +13,15 @@ BACKUPS_DIR="${BACKUPS_DIR:-vm.backups}"
 NAME="${NAME:-}"
 BACKUP_INCLUDE_IPSW="${BACKUP_INCLUDE_IPSW:-0}"
 
+validate_backup_name() {
+    local name="$1"
+    local label="${2:-NAME}"
+    if [[ "$name" == */* || "$name" == .* ]]; then
+        echo "ERROR: ${label} must be a simple identifier (no slashes or leading dots)."
+        exit 1
+    fi
+}
+
 # --- Parse args ---
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -40,6 +49,8 @@ if [[ -z "${NAME}" ]]; then
     fi
     exit 1
 fi
+
+validate_backup_name "${NAME}"
 
 TARGET="${BACKUPS_DIR}/${NAME}"
 
@@ -80,6 +91,8 @@ if [[ -d "${VM_DIR}" && -f "${VM_DIR}/config.plist" ]]; then
             exit 1
         fi
     fi
+
+    validate_backup_name "${CURRENT}" "Current VM name"
 
     if [[ "${CURRENT}" == "${NAME}" ]]; then
         echo "'${NAME}' is already the active VM."


### PR DESCRIPTION
## Summary

This PR aligns `vm_restore.sh` and `vm_switch.sh` with the name validation already used by `vm_backup.sh`.

## Why

`vm_backup.sh` already rejects backup names with slashes or leading dots, but `vm_restore.sh` and `vm_switch.sh` still accepted those values and interpolated them directly into backup paths.

That made the VM backup toolchain inconsistent and allowed path-shaped names on restore/switch even though backup creation already forbids them.

## Changes

- Added `validate_backup_name()` to `vm_restore.sh`
- Added `validate_backup_name()` to `vm_switch.sh`
- `vm_restore.sh` now validates `NAME` before constructing `${BACKUPS_DIR}/${NAME}`
- `vm_switch.sh` now validates:
  - the target backup name (`NAME`)
  - the current VM name before saving it as a backup

## Validation

- `zsh -n scripts/vm_restore.sh scripts/vm_switch.sh`
- Negative checks:
  - `NAME=../bad zsh scripts/vm_restore.sh`
  - `NAME=../bad zsh scripts/vm_switch.sh`
  - both now fail early with a clear identifier error
