### PR TITLE
boot_preflight: skip /dev/tty fallback without a tty

### DIFF
--- a/scripts/boot_host_preflight.sh
+++ b/scripts/boot_host_preflight.sh
@@ -82,14 +82,20 @@ RESEARCH_GUEST_STATUS="$(
       fi
     fi
     # No Macintosh HD found, or auto-select failed — prompt interactively
-    printf '%s\n' "$_out" >/dev/tty
-    printf 'Pick a macOS installation: ' >/dev/tty
-    read _choice </dev/tty
-    if [[ -n "$_choice" ]]; then
-      printf '%s\n' "$_choice" | csrutil allow-research-guests status 2>/dev/null \
-        | grep -o 'Allow Research Guests status:.*' || echo 'unavailable'
+    # only when a controlling TTY exists. Non-interactive runs should degrade
+    # cleanly instead of failing on /dev/tty access under set -e.
+    if { : >/dev/tty; } 2>/dev/null; then
+      printf '%s\n' "$_out" >/dev/tty
+      printf 'Pick a macOS installation: ' >/dev/tty
+      read _choice </dev/tty
+      if [[ -n "$_choice" ]]; then
+        printf '%s\n' "$_choice" | csrutil allow-research-guests status 2>/dev/null \
+          | grep -o 'Allow Research Guests status:.*' || echo 'unavailable'
+      else
+        echo 'unavailable'
+      fi
     else
-      echo 'unavailable'
+      echo 'unavailable (multiple installs; no interactive tty)'
     fi
   fi
 )"


### PR DESCRIPTION
## Summary

This PR makes `boot_host_preflight.sh` degrade cleanly when the `csrutil allow-research-guests status` multi-volume fallback runs without an interactive controlling TTY.

## Why

The recent multi-volume handling path writes to and reads from `/dev/tty` when auto-selection cannot resolve a volume. In non-interactive runs, `/dev/tty` may be unavailable, which can make the fallback path fail under `set -e`.

## Changes

- Before prompting on `/dev/tty`, check whether a controlling TTY is actually available
- If no TTY is available, return a descriptive unavailable status instead of attempting the interactive prompt

## Validation

- `zsh -n scripts/boot_host_preflight.sh`
- `zsh -c 'if { : >/dev/tty; } 2>/dev/null; then echo tty; else echo no-tty; fi'`
- `zsh scripts/boot_host_preflight.sh --quiet`
