### PR TITLE
boot: add --install-ipa auto-install option

### DIFF
--- a/sources/vphone-cli/VPhoneAppDelegate.swift
+++ b/sources/vphone-cli/VPhoneAppDelegate.swift
@@ -13,6 +13,7 @@ class VPhoneAppDelegate: NSObject, NSApplicationDelegate {
     private var appWindowController: VPhoneAppWindowController?
     private var locationProvider: VPhoneLocationProvider?
     private var sigintSource: DispatchSourceSignal?
+    private var didAttemptAutoInstall = false
 
     init(cli: VPhoneBootCLI) {
         self.cli = cli
@@ -154,6 +155,9 @@ class VPhoneAppDelegate: NSObject, NSApplicationDelegate {
                 }
                 mc?.syncBatteryFromHost()
                 mc?.syncLowPowerModeFromHost()
+                Task { @MainActor [weak self] in
+                    await self?.installPackageIfRequested(caps: caps)
+                }
             }
             control.onDisconnect = { [weak mc, weak provider = locationProvider] in
                 mc?.updateConnectAvailability(available: false)
@@ -174,11 +178,50 @@ class VPhoneAppDelegate: NSObject, NSApplicationDelegate {
                 } else {
                     print("[location] guest does not support location simulation")
                 }
+                Task { @MainActor [weak self] in
+                    await self?.installPackageIfRequested(caps: caps)
+                }
             }
             control.onDisconnect = { [weak provider = locationProvider] in
                 provider?.stopReplay()
                 provider?.stopForwarding()
             }
+        }
+    }
+
+    @MainActor
+    private func installPackageIfRequested(caps: [String]) async {
+        guard !didAttemptAutoInstall else { return }
+        guard let packageURL = cli.installPackageURL else { return }
+
+        guard FileManager.default.fileExists(atPath: packageURL.path) else {
+            didAttemptAutoInstall = true
+            print("[install] requested package not found: \(packageURL.path)")
+            return
+        }
+        guard VPhoneInstallPackage.isSupportedFile(packageURL) else {
+            didAttemptAutoInstall = true
+            print("[install] unsupported package type: \(packageURL.path)")
+            return
+        }
+        guard caps.contains("ipa_install") else {
+            print(
+                "[install] guest does not advertise ipa_install; reconnect or reboot the guest so the updated daemon can take over"
+            )
+            return
+        }
+        guard let control else {
+            print("[install] control channel is not ready")
+            return
+        }
+
+        didAttemptAutoInstall = true
+        print("[install] auto-installing \(packageURL.lastPathComponent)")
+        do {
+            let result = try await control.installIPA(localURL: packageURL)
+            print("[install] \(result)")
+        } catch {
+            print("[install] failed: \(error)")
         }
     }
 

--- a/sources/vphone-cli/VPhoneCLI.swift
+++ b/sources/vphone-cli/VPhoneCLI.swift
@@ -44,9 +44,19 @@ struct VPhoneBootCLI: ParsableCommand {
     @Option(help: "Path to signed vphoned binary for guest auto-update")
     var vphonedBin: String = ".vphoned.signed"
 
+    @Option(
+        help: "Automatically install the given IPA/TIPA after the guest control channel connects.",
+        transform: URL.init(fileURLWithPath:)
+    )
+    var installIPA: URL?
+
     /// DFU mode runs headless (no GUI).
     var noGraphics: Bool {
         dfu
+    }
+
+    var installPackageURL: URL? {
+        installIPA?.standardizedFileURL
     }
 
     /// Resolve final options by merging manifest values.


### PR DESCRIPTION
## Summary

This PR adds a `--install-ipa` boot option that automatically installs an IPA/TIPA after the guest control channel connects.

## Why

When iterating on app installs, it is useful to boot directly into an installation flow instead of waiting for the UI and manually selecting the package each time.

## Changes

- Added `--install-ipa` to `VPhoneBootCLI`
- Triggered host-side auto-install after control-channel connect
- Kept the install pending until the guest actually advertises `ipa_install`
- Removed the checked-in patch export from the tree

## Notes

- If the first connection is an older `vphoned` instance without `ipa_install`, the request now retries on a later reconnect after daemon handoff
- Invalid paths and unsupported package extensions still fail once and stop retrying
