### PR TITLE
boot: validate --install-ipa before startup

### DIFF
--- a/sources/vphone-cli/VPhoneCLI.swift
+++ b/sources/vphone-cli/VPhoneCLI.swift
@@ -45,7 +45,7 @@ struct VPhoneBootCLI: ParsableCommand {
     var vphonedBin: String = ".vphoned.signed"
 
     @Option(
-        help: "Automatically install the given IPA/TIPA after the guest control channel connects.",
+        help: "Automatically install the given IPA/TIPA after the guest control channel connects. Unavailable with --dfu.",
         transform: URL.init(fileURLWithPath:)
     )
     var installIPA: URL?
@@ -57,6 +57,26 @@ struct VPhoneBootCLI: ParsableCommand {
 
     var installPackageURL: URL? {
         installIPA?.standardizedFileURL
+    }
+
+    mutating func validate() throws {
+        if dfu, let packageURL = installPackageURL {
+            throw ValidationError(
+                "`--install-ipa` is unavailable with `--dfu` because DFU mode does not start the guest control channel: \(packageURL.path)"
+            )
+        }
+
+        guard let packageURL = installPackageURL else { return }
+
+        guard FileManager.default.fileExists(atPath: packageURL.path) else {
+            throw ValidationError("`--install-ipa` file does not exist: \(packageURL.path)")
+        }
+
+        guard VPhoneInstallPackage.isSupportedFile(packageURL) else {
+            throw ValidationError(
+                "`--install-ipa` only supports .ipa or .tipa packages: \(packageURL.lastPathComponent)"
+            )
+        }
     }
 
     /// Resolve final options by merging manifest values.


### PR DESCRIPTION
## Summary
- fail fast when `--install-ipa` is combined with `--dfu`
- validate the requested package path before VM startup
- reject unsupported package types before the boot flow begins
- clarify in `--help` that `--install-ipa` is unavailable with `--dfu`

## Validation
- `make build`

## Notes
- Attempted to exercise the new CLI validation paths directly, but the built binary is killed with exit code 137 in this local environment even for `--help`, so runtime validation could not be captured here.