### PR TITLE
Fix missing ipsw dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Boot into Recovery (long press power button), open Terminal, then choose one set
 **Install dependencies:**
 
 ```bash
-brew install aria2 ideviceinstaller wget gnu-tar openssl@3 ldid-procursus sshpass keystone autoconf automake pkg-config libtool cmake
+brew install aria2 ideviceinstaller wget gnu-tar openssl@3 ldid-procursus sshpass keystone autoconf automake pkg-config libtool cmake ipsw
 ```
 
 `scripts/fw_prepare.sh` prefers `aria2c` for faster multi-connection downloads and falls back to `curl` or `wget` when needed.


### PR DESCRIPTION
## Summary

This PR improves the handling of the missing `ipsw` dependency when running JB setup.

## Reproduction

```bash
make JB=1 setup_machine
```

## Current behavior

The setup fails with:

```text
=== CFW install ===
make[1]: Entering directory '/Users/a/b/c/vphone-cli'
cd vm && SSH_PORT="29182" _VPHONE_PATH="$PATH" zsh "/Users/a/b/c/vphone-cli/scripts/cfw_install_jb.sh" .
[*] cfw_install_jb.sh — Installing CFW + JB extensions...

[*] cfw_install.sh — Installing CFW on vphone...
[-] 'ipsw' not found. Install: brew install blacktop/tap/ipsw
make[1]: *** [Makefile:332: cfw_install_jb] Error 1
make[1]: Leaving directory '/Users/a/b/c/vphone-cli'
make: *** [Makefile:115: setup_machine] Error 2
```

## Changes

- docs: add ipsw install requirement