### PR TITLE
setup_machine: fix ECID mismatch race in DFU recovery wait

### DIFF
--- a/scripts/setup_machine.sh
+++ b/scripts/setup_machine.sh
@@ -733,6 +733,10 @@ start_boot_dfu() {
   kill_stale_vphone_procs
   check_vm_storage_locks
 
+  # Remove stale prediction file so load_device_identity waits for the fresh
+  # one written by this boot, avoiding an ECID mismatch race.
+  rm -f "${VM_DIR_ABS}/udid-prediction.txt"
+
   : > "$DFU_LOG"
   echo "[*] Starting DFU boot in background..."
   (make boot_dfu >"$DFU_LOG" 2>&1) &


### PR DESCRIPTION
## Summary
- On re-runs of `make setup_machine`, `load_device_identity` reads a stale `udid-prediction.txt` from a previous boot before the new DFU VM has written the current ECID
- `wait_for_recovery` then polls `irecovery` with the wrong ECID, hanging indefinitely at `"Waiting for recovery/DFU endpoint..."`
- Fix: remove the stale prediction file in `start_boot_dfu` so `load_device_identity` blocks until the fresh file is written

Fixes #255

## Test plan
- [x] Deleted `vm/Disk.img` + `vm/SEPStorage`, ran `make setup_machine` end-to-end — completed successfully through restore, ramdisk, CFW install, and first boot
- [x] Confirmed `irecovery` polls with the correct ECID after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)