### PR TITLE
setup: fix several make setup_machine bootstrap failures

### DIFF
--- a/scripts/setup_libimobiledevice.sh
+++ b/scripts/setup_libimobiledevice.sh
@@ -117,10 +117,10 @@ stage_repo_source "libirecovery"
 
 # PR #150: register iPhone99,11 / vresearch101ap for PCC research VMs
 if ! grep -q 'vresearch101ap' "$SRC/libirecovery/src/libirecovery.c"; then
-    if ! (cd "$SRC/libirecovery" && patch -p1 --batch --forward --dry-run <"$SCRIPT_DIR/patches/libirecovery-pcc-vm.patch" >/dev/null); then
+    if ! (cd "$SRC/libirecovery" && /usr/bin/patch -p1 --batch --forward --dry-run <"$SCRIPT_DIR/patches/libirecovery-pcc-vm.patch" >/dev/null); then
         die "Failed to validate libirecovery PCC patch — check context"
     fi
-    if ! (cd "$SRC/libirecovery" && patch -p1 --batch --forward <"$SCRIPT_DIR/patches/libirecovery-pcc-vm.patch" >"$LOG/libirecovery-pcc-vm.patch.log" 2>&1); then
+    if ! (cd "$SRC/libirecovery" && /usr/bin/patch -p1 --batch --forward <"$SCRIPT_DIR/patches/libirecovery-pcc-vm.patch" >"$LOG/libirecovery-pcc-vm.patch.log" 2>&1); then
         die "Failed to apply libirecovery PCC patch — see $LOG/libirecovery-pcc-vm.patch.log"
     fi
     grep -q 'vresearch101ap' "$SRC/libirecovery/src/libirecovery.c" ||

--- a/scripts/setup_machine.sh
+++ b/scripts/setup_machine.sh
@@ -732,8 +732,14 @@ ensure_amfi_bypass() {
       return 0
     fi
     echo "[*] Activating AMFI bypass (amfree) for .build..."
-    sudo amfree --path "$build_path" && return 0
+    if sudo amfree --path "$build_path"; then
+      return 0
+    fi
     echo "[!] amfree activation failed; boot may be killed by AMFI" >&2
+    if [[ "${ALLOW_AMFI_BYPASS_SOFTFAIL:-0}" != "1" ]]; then
+      return 1
+    fi
+    echo "[!] Continuing despite AMFI bypass failure (ALLOW_AMFI_BYPASS_SOFTFAIL=1)" >&2
     return 0
   fi
   # Fall back to amfidont helper script for vphone if amfree is not available.

--- a/scripts/setup_machine.sh
+++ b/scripts/setup_machine.sh
@@ -736,9 +736,15 @@ ensure_amfi_bypass() {
     echo "[!] amfree activation failed; boot may be killed by AMFI" >&2
     return 0
   fi
-  # Fall back to make amfidont_allow_vphone (handles amfidont path internally)
-  make amfidont_allow_vphone 2>/dev/null || \
-    echo "[!] amfidont_allow_vphone failed; boot may be killed by AMFI" >&2
+  # Fall back to amfidont helper script for vphone if amfree is not available.
+  local amfidont_script="${PROJECT_ROOT}/scripts/start_amfidont_for_vphone.sh"
+  if [[ -x "$amfidont_script" ]]; then
+    echo "[*] Activating AMFI bypass (amfidont) for .build via $amfidont_script..."
+    "$amfidont_script" || \
+      echo "[!] amfidont helper script failed; boot may be killed by AMFI" >&2
+  else
+    echo "[!] AMFI bypass helper not found or not executable at $amfidont_script; boot may be killed by AMFI" >&2
+  fi
 }
 
 start_boot_dfu() {

--- a/scripts/setup_machine.sh
+++ b/scripts/setup_machine.sh
@@ -723,12 +723,32 @@ run_make() {
   make "$@"
 }
 
+ensure_amfi_bypass() {
+  # amfree hook is session-scoped; re-activate if not already covering .build.
+  local build_path="${PROJECT_ROOT}/.build"
+  if command -v amfree &>/dev/null; then
+    if amfree --list 2>/dev/null | grep -qF "$build_path"; then
+      echo "[+] AMFI bypass already active for .build"
+      return 0
+    fi
+    echo "[*] Activating AMFI bypass (amfree) for .build..."
+    sudo amfree --path "$build_path" && return 0
+    echo "[!] amfree activation failed; boot may be killed by AMFI" >&2
+    return 0
+  fi
+  # Fall back to make amfidont_allow_vphone (handles amfidont path internally)
+  make amfidont_allow_vphone 2>/dev/null || \
+    echo "[!] amfidont_allow_vphone failed; boot may be killed by AMFI" >&2
+}
+
 start_boot_dfu() {
   mkdir -p "$LOG_DIR"
 
   if [[ -n "$DFU_PID" ]] && kill -0 "$DFU_PID" 2>/dev/null; then
     return
   fi
+
+  ensure_amfi_bypass
 
   kill_stale_vphone_procs
   check_vm_storage_locks

--- a/scripts/setup_tools.sh
+++ b/scripts/setup_tools.sh
@@ -24,9 +24,9 @@ ensure_repo_submodule() {
 
 # ── Brew packages ──────────────────────────────────────────────
 
-echo "[1/5] Checking brew packages..."
+echo "[1/6] Checking brew packages..."
 
-BREW_PACKAGES=(aria2 gnu-tar openssl@3 ldid-procursus sshpass)
+BREW_PACKAGES=(aria2 gnu-tar openssl@3 ldid-procursus sshpass blacktop/tap/ipsw)
 BREW_MISSING=()
 
 for pkg in "${BREW_PACKAGES[@]}"; do
@@ -44,7 +44,15 @@ fi
 
 # ── Trustcache ─────────────────────────────────────────────────
 
-echo "[2/5] trustcache"
+echo "[2/6] vendor submodules"
+ensure_repo_submodule "vendor/swift-argument-parser"
+ensure_repo_submodule "vendor/Dynamic"
+ensure_repo_submodule "vendor/MachOKit"
+ensure_repo_submodule "vendor/libcapstone-spm"
+ensure_repo_submodule "vendor/libimg4-spm"
+ensure_repo_submodule "scripts/resources"
+
+echo "[3/6] trustcache"
 
 TRUSTCACHE_BIN="$TOOLS_PREFIX/bin/trustcache"
 if [[ -x "$TRUSTCACHE_BIN" ]]; then
@@ -73,7 +81,7 @@ fi
 
 # ── insert_dylib ───────────────────────────────────────────────
 
-echo "[3/5] insert_dylib"
+echo "[4/6] insert_dylib"
 
 INSERT_DYLIB_BIN="$TOOLS_PREFIX/bin/insert_dylib"
 if [[ -x "$INSERT_DYLIB_BIN" ]]; then
@@ -89,12 +97,12 @@ fi
 
 # ── Libimobiledevice ──────────────────────────────────────────
 
-echo "[4/5] libimobiledevice"
+echo "[5/6] libimobiledevice"
 bash "$SCRIPT_DIR/setup_libimobiledevice.sh"
 
 # ── Python venv ────────────────────────────────────────────────
 
-echo "[5/5] Python venv"
+echo "[6/6] Python venv"
 zsh "$SCRIPT_DIR/setup_venv.sh"
 
 echo ""

--- a/scripts/start_amfidont_for_vphone.sh
+++ b/scripts/start_amfidont_for_vphone.sh
@@ -12,10 +12,25 @@ SCRIPT_DIR="${0:A:h}"
 PROJECT_ROOT="${SCRIPT_DIR:h}"
 BUNDLE_BIN="${PROJECT_ROOT}/.build/vphone-cli.app/Contents/MacOS/vphone-cli"
 AMFIDONT_BIN="${HOME}/Library/Python/3.9/bin/amfidont"
+AMFREE_BIN="$(command -v amfree 2>/dev/null || true)"
+
+# ── amfree path (preferred if amfidont is absent) ────────────────
+
+if [[ ! -x "$AMFIDONT_BIN" && -x "$AMFREE_BIN" ]]; then
+  AMFI_PATH="${PROJECT_ROOT}/.build"
+  echo "[*] Project root:      $PROJECT_ROOT"
+  echo "[*] AMFI path:         $AMFI_PATH"
+  echo "[*] Using amfree (amfidont not installed)"
+  sudo "$AMFREE_BIN" --path "$AMFI_PATH"
+  exit $?
+fi
+
+# ── amfidont path ────────────────────────────────────────────────
 
 [[ -x "$AMFIDONT_BIN" ]] || {
-  echo "amfidont not found at $AMFIDONT_BIN" >&2
-  echo "Install it first: xcrun python3 -m pip install --user amfidont" >&2
+  echo "Neither amfidont nor amfree found." >&2
+  echo "Install amfree: brew install amfree" >&2
+  echo "Or install amfidont: xcrun python3 -m pip install --user amfidont" >&2
   exit 1
 }
 


### PR DESCRIPTION
## Summary

Fixes four independent failures encountered during a fresh `make setup_machine` run:

- **`patch: out of memory`** — `setup_libimobiledevice.sh` now calls `/usr/bin/patch` explicitly. The system `patch` from Anaconda (`/opt/homebrew/anaconda3/bin/patch`, GNU patch 2.7.6) OOMs when processing `diff --git` format patches against the 134 KB libirecovery source.

- **`amfidont` not found / `amfree` ignored** — `start_amfidont_for_vphone.sh` now falls back to `amfree --path` when `amfidont` is not installed. Error message updated to mention both options.

- **Missing vendor submodules** — `setup_tools.sh` only initialized `vendor/swift-argument-parser`. Added the remaining four vendor submodules (`Dynamic`, `MachOKit`, `libcapstone-spm`, `libimg4-spm`) and `scripts/resources` (contains `ramdisk_input.tar.zst`). Also added `blacktop/tap/ipsw` to the brew package list (required by `cfw_install.sh`).

- **AMFI bypass expires between runs** — `setup_machine.sh` now calls `ensure_amfi_bypass()` from `start_boot_dfu`. The `amfree` hook is session-scoped and silently absent on each new terminal; without it `boot_binary_check` kills the signed binary (exit 137) before writing `udid-prediction.txt`. The helper checks whether the hook already covers `.build` and only re-activates if needed.

## Test plan

- [ ] Fresh clone: `make setup_machine` completes end-to-end without manual intervention (given `SUDO_PASSWORD` or interactive sudo)
- [ ] Verify `setup_tools` initializes all submodules on a clean checkout
- [ ] Verify `make amfidont_allow_vphone` succeeds with `amfree` installed and `amfidont` absent
- [ ] Verify libirecovery patch applies correctly on a system with Anaconda in PATH

🤖 Generated with [Claude Code](https://claude.com/claude-code)