### PR TITLE
restore: offline restore via fake TSS server + AEA staging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,7 @@ help:
 	@echo "Restore:"
 	@echo "  make restore_get_shsh        Dump SHSH response from Apple"
 	@echo "  make restore                 idevicerestore to device"
+	@echo "  make restore_offline         idevicerestore offline — pre-decrypts AEA images, serves cached .shsh via local TSS"
 	@echo ""
 	@echo "Ramdisk:"
 	@echo "  make ramdisk_build           Build signed SSH ramdisk"
@@ -289,7 +290,7 @@ fw_patch_jb: patcher_build
 # Restore
 # ═══════════════════════════════════════════════════════════════════
 
-.PHONY: restore_get_shsh restore
+.PHONY: restore_get_shsh restore restore_offline
 
 restore_get_shsh:
 	cd $(VM_DIR) && "$(CURDIR)/$(IDEVICERESTORE)" \
@@ -302,6 +303,38 @@ restore:
 		$(if $(RESTORE_UDID),-u $(RESTORE_UDID),) \
 		$(if $(RESTORE_ECID),-i $(RESTORE_ECID),) \
 		-e -y ./iPhone*_Restore
+
+restore_offline:
+	@SHSH=$$(ls "$(CURDIR)/$(VM_DIR)/shsh/"*.shsh 2>/dev/null | head -1); \
+	if [ -z "$$SHSH" ]; then \
+		echo "[-] No .shsh file in $(VM_DIR)/shsh/ — run 'make restore_get_shsh' first"; \
+		exit 1; \
+	fi; \
+	RESTORE_SRC=$$(echo "$(CURDIR)/$(VM_DIR)/iPhone"*_Restore); \
+	RESTORE_TMP=$$(mktemp -d /tmp/vphone_restore.XXXXXX); \
+	cp -al "$$RESTORE_SRC/." "$$RESTORE_TMP/"; \
+	echo "[+] Decrypting AEA images..."; \
+	for aea in "$$RESTORE_SRC"/*.dmg.aea; do \
+		[ -f "$$aea" ] || continue; \
+		[ "$$(xxd -l 4 -p "$$aea")" = "41454131" ] || continue; \
+		base=$$(basename "$$aea"); \
+		rm "$$RESTORE_TMP/$$base"; \
+		ipsw fw aea -o "$$RESTORE_TMP" "$$aea" 2>/dev/null; \
+		mv "$$RESTORE_TMP/$${base%.aea}" "$$RESTORE_TMP/$$base"; \
+	done; \
+	echo "[+] Restoring offline with SHSH: $$(basename $$SHSH)"; \
+	python3 "$(CURDIR)/$(SCRIPTS)/tss_server.py" 49494 "$$SHSH" & \
+	TSS_PID=$$!; \
+	sleep 1; \
+	"$(CURDIR)/$(IDEVICERESTORE)" \
+		$(if $(RESTORE_UDID),-u $(RESTORE_UDID),) \
+		$(if $(RESTORE_ECID),-i $(RESTORE_ECID),) \
+		-e -y -s "http://127.0.0.1:49494" \
+		"$$RESTORE_TMP"; \
+	STATUS=$$?; \
+	kill $$TSS_PID 2>/dev/null || true; \
+	rm -rf "$$RESTORE_TMP"; \
+	exit $$STATUS
 
 # ═══════════════════════════════════════════════════════════════════
 # Ramdisk

--- a/scripts/tss_server.py
+++ b/scripts/tss_server.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Minimal fake TSS server — serves a cached SHSH blob as a TSS response.
+
+Usage: tss_server.py <port> <shsh_file>
+
+idevicerestore POSTs a TSS request to this server. We ignore the request body
+and return a plist dict containing the pre-downloaded ApImg4Ticket. This lets
+idevicerestore run fully offline without contacting Apple's TSS servers.
+"""
+import gzip
+import plistlib
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+def load_ticket(shsh_path):
+    with gzip.open(shsh_path, "rb") as f:
+        pl = plistlib.load(f)
+    return bytes(pl["ApImg4Ticket"])
+
+
+class TSSHandler(BaseHTTPRequestHandler):
+    ticket = None
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        self.rfile.read(length)
+        plist_xml = plistlib.dumps({"ApImg4Ticket": self.ticket}, fmt=plistlib.FMT_XML)
+        # libtatsu expects: STATUS=0&MESSAGE=SUCCESS&REQUEST_STRING=<?xml ...>
+        body = b"STATUS=0&MESSAGE=SUCCESS&REQUEST_STRING=" + plist_xml
+        self.send_response(200)
+        self.send_header("Content-Type", "text/xml; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <port> <shsh_file>", file=sys.stderr)
+        sys.exit(1)
+    port = int(sys.argv[1])
+    TSSHandler.ticket = load_ticket(sys.argv[2])
+    HTTPServer(("127.0.0.1", port), TSSHandler).serve_forever()


### PR DESCRIPTION
## Summary

- Adds `make restore_offline` for fully offline idevicerestore without patching idevicerestore itself
- Adds `scripts/tss_server.py`: minimal fake TSS server that serves a cached SHSH blob in the format libtatsu expects (`STATUS=0&MESSAGE=SUCCESS&REQUEST_STRING=<plist>`)
- AEA-encrypted DMGs are pre-decrypted into a hardlinked `/tmp` staging dir before restore, leaving the original restore directory (with `.dmg.aea` files) untouched for subsequent `cfw_install` runs

## How it works

1. `make restore_get_shsh` — run once to dump the SHSH blob from Apple into `vm/shsh/`
2. `make restore_offline` — on subsequent restores:
   - hardlinks the restore dir into `/tmp/vphone_restore.XXXXXX`
   - decrypts any `.dmg.aea` files in the staging dir (originals untouched)
   - starts `tss_server.py` on `127.0.0.1:49494`
   - runs `idevicerestore -s http://127.0.0.1:49494` against the staging dir
   - cleans up staging dir

## Test plan

- [ ] `make restore_get_shsh` with device in DFU — confirms `.shsh` saved to `vm/shsh/`
- [ ] `make restore_offline` with device in DFU — confirm restore completes without contacting Apple TSS
- [ ] `make cfw_install` after offline restore — confirm `.dmg.aea` files still present and decrypt correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)