### PR TITLE
make: fix vm_list exit code when backups exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ vm_list:
 			fi; \
 			found=1; \
 		done; \
-		[ "$$found" = "0" ] && echo "  (no backups yet — run: make vm_backup NAME=<name>)"; \
+		if [ "$$found" = "0" ]; then echo "  (no backups yet — run: make vm_backup NAME=<name>)"; fi; \
 	else \
 		echo "  (no backups yet — run: make vm_backup NAME=<name>)"; \
 	fi


### PR DESCRIPTION
## Summary

`make vm_list` printed the correct output but returned a non-zero exit code when backups existed.

The target ended with:

```make
[ "$$found" = "0" ] && echo "..."
```

When backups existed, the condition evaluated false and returned exit 1, which propagated as a make rule failure.

## Change

Replace the trailing conditional with `if ... fi` so the target exits successfully in both cases.

## Verification

- With backups present: `make vm_list; echo $?` -> `0`
- With no backups: `make vm_list; echo $?` -> `0`