### PR TITLE
Fix Video Acceleration

### DIFF
--- a/sources/vphone-cli/VPhoneVirtualMachine.swift
+++ b/sources/vphone-cli/VPhoneVirtualMachine.swift
@@ -215,12 +215,22 @@ class VPhoneVirtualMachine: NSObject, VZVirtualMachineDelegate {
             config.serialPorts = [serialPort]
             print("[vphone] PL011 serial port attached (interactive)")
         }
+        
+        if let obj1 = Dynamic._VZMacVideoToolboxDeviceConfiguration().asObject,
+           let obj2 = Dynamic._VZMacNeuralEngineDeviceConfiguration().asObject {
+            Dynamic(config)._setAcceleratorDevices([obj1,obj2])
+            print("[vphone] Accelerator devices configured")
+        }
 
         // Multi-touch (USB touch screen)
         if let obj = Dynamic._VZUSBTouchScreenConfiguration().asObject {
             Dynamic(config)._setMultiTouchDevices([obj])
             print("[vphone] USB touch screen configured")
         }
+        
+        let obj = VZVirtioEntropyDeviceConfiguration()
+        config.entropyDevices = [obj]
+        print("[vphone] Entropy device configured")
 
         config.keyboards = [VZUSBKeyboardConfiguration()]
 


### PR DESCRIPTION
Before, the video acceleration did not work. This was noticeable, for example, in the Apple TV App, where the video previews did not load and left empty boxes.

This can be fixed by adding vphone accelerators. This PR adds:
- The Video Toolbox Device
- The Neural Engine Device
- The Entropy Device

With this PR, the previews load. (I would love to provide screenshots as proof, but the DRM protection is preventing that 😅 )