### PR TITLE
Patchless hardening

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ help:
 	@echo "  make setup_machine                   Full setup through First Boot"
 	@echo "    Options: JB=1                      Jailbreak firmware/CFW path"
 	@echo "             DEV=1                     Dev firmware/CFW path (dev TXM + cfw_install_dev)"
+	@echo "             LESS=1                    Build, keeping iOS security mitigations enabled. 
 	@echo "             SKIP_PROJECT_SETUP=1      Skip setup_tools/build"
 	@echo "             NONE_INTERACTIVE=1        Auto-continue prompts + boot analysis"
 	@echo "             SUDO_PASSWORD=...         Preload sudo credential for setup flow"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Four patch variants are available with increasing levels of security bypass:
 
 | Variant         | Boot Chain  |    CFW    | Make Targets                        |
 | --------------- | :---------: | :-------: | ----------------------------------- |
-| **Patchless**   | 3 patches   | 2 phases  | `fw_patch_less` (root) + `boot_less`|
+| **Patchless**   | 3 patches   | 2 phases  | `fw_patch_less` + `boot_less`       |
 | **Regular**     | 41 patches  | 10 phases | `fw_patch` + `cfw_install`          |
 | **Development** | 52 patches  | 12 phases | `fw_patch_dev` + `cfw_install_dev`  |
 | **Jailbreak**   | 112 patches | 14 phases | `fw_patch_jb` + `cfw_install_jb`    |

--- a/docs/README_ja.md
+++ b/docs/README_ja.md
@@ -21,7 +21,7 @@ Apple の Virtualization.framework と PCC の研究用 VM インフラを使用
 
 | バリアント | ブートチェーン |     CFW     | Make ターゲット                              |
 | ---------- | :------------: | :---------: | -------------------------------------------- |
-| **Patchless** | 3 パッチ     | 2 フェーズ  | `fw_patch_less` (root) + `boot_less`         |
+| **Patchless** | 3 パッチ     | 2 フェーズ  | `fw_patch_less` + `boot_less`              |
 | **通常版** |   41 パッチ    | 10 フェーズ | `fw_patch` + `cfw_install`                   |
 | **開発版** |   52 パッチ    | 12 フェーズ | `fw_patch_dev` + `cfw_install_dev`           |
 | **脱獄版** |   112 パッチ   | 14 フェーズ | `fw_patch_jb` + `cfw_install_jb`             |

--- a/docs/README_ko.md
+++ b/docs/README_ko.md
@@ -21,7 +21,7 @@ PCC 리서치 VM 인프라와 Apple의 Virtualization.framework를 사용하여 
 
 | 변형         | 부트 체인 |    CFW    | Make 타겟                                   |
 | ------------ | :-------: | :-------: | ------------------------------------------- |
-| **Patchless** |  3 패치   | 2 페이즈  | `fw_patch_less` (root) + `boot_less`        |
+| **Patchless** |  3 패치   | 2 페이즈  | `fw_patch_less` + `boot_less`             |
 | **일반**     |  41 패치  | 10 페이즈 | `fw_patch` + `cfw_install`                  |
 | **개발**     |  52 패치  | 12 페이즈 | `fw_patch_dev` + `cfw_install_dev`          |
 | **탈옥**     | 112 패치  | 14 페이즈 | `fw_patch_jb` + `cfw_install_jb`            |

--- a/docs/README_zh.md
+++ b/docs/README_zh.md
@@ -21,7 +21,7 @@
 
 | 变体          | 启动链     | 自定义固件 | Make 目标                                   |
 | ------------- | :--------: | :--------: | ------------------------------------------- |
-| **Patchless** | 3 个补丁   | 2 个阶段   | `fw_patch_less` (root) + `boot_less`        |
+| **Patchless** | 3 个补丁   | 2 个阶段   | `fw_patch_less` + `boot_less`              |
 | **常规版**    | 41 个补丁  | 10 个阶段  | `fw_patch` + `cfw_install`                  |
 | **开发版**    | 52 个补丁  | 12 个阶段  | `fw_patch_dev` + `cfw_install_dev`          |
 | **越狱版**    | 112 个补丁 | 14 个阶段  | `fw_patch_jb` + `cfw_install_jb`            |

--- a/sources/FirmwarePatcher/Filesystem/CryptexFilesystemPatcher.swift
+++ b/sources/FirmwarePatcher/Filesystem/CryptexFilesystemPatcher.swift
@@ -70,11 +70,11 @@ public final class CryptexFilesystemPatcher: Patcher {
         let trustcachePath = try createTrustcache(filesystem: unencryptedImage)
         
         print("Creating mtree")
-        try removeSpecificSystemFiles(filesystem: unencryptedImage)
+        let didEdit = try removeSpecificSystemFiles(filesystem: unencryptedImage)
         let mtreePath = try createMtree(filesystem: unencryptedImage)
         
         print("Creating DigestDB and Root Hash")
-        let (digestDbPath, rootHashPath) = try createDigestAndHash(filesystem: unencryptedImage, mtree: mtreePath)
+        let (digestDbPath, rootHashPath) = try createDigestAndHash(filesystem: unencryptedImage, mtree: mtreePath, remap: didEdit)
         let metadataPath = try compressCanonicalMetadata(mtree: mtreePath, digestDb: digestDbPath)
         let rootHashContainer = try wrapRootHash(rootHashPath)
         
@@ -339,7 +339,7 @@ public final class CryptexFilesystemPatcher: Patcher {
         return im4pPath
     }
     
-    func createDigestAndHash(filesystem: URL, mtree: URL) throws -> (URL, URL) {
+    func createDigestAndHash(filesystem: URL, mtree: URL, remap: Bool) throws -> (URL, URL) {
         let (device, mount) = try attachImage(path: filesystem)
         defer { try? detachImage(deviceNode: device) }
 
@@ -357,12 +357,14 @@ public final class CryptexFilesystemPatcher: Patcher {
             <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
             <plist version="1.0">
             <dict>
-                <key>MODIFICATION</key>
-                <integer>\(modificationTime)</integer>
+            \(remap ? """
+                    <key>MODIFICATION</key>
+                    <integer>\(modificationTime)</integer>
+                """ : "")
             </dict>
             </plist>
             """
-        print("Used time: \(modificationTime)")
+        print("Used time: \(remap ? modificationTime : "none")")
         FileManager.default.createFile(atPath: mtreeRemapPath.path, contents: remapContent.data(using: .utf8))
 
         try unmount(mount: mount)
@@ -427,18 +429,23 @@ public final class CryptexFilesystemPatcher: Patcher {
         return mtreeFile
     }
     
-    func removeSpecificSystemFiles(filesystem: URL) throws {
+    func removeSpecificSystemFiles(filesystem: URL) throws -> Bool {
         let (device, mount) = try attachImage(path: filesystem, forceRW: true)
         defer { try? detachImage(deviceNode: device) }
         
         let removedPaths = [
-//            "/private/var/MobileAsset/PreinstalledAssets",
+            "/private/var/MobileAsset/PreinstalledAssets",
             "/private/var/MobileAsset/PreinstalledAssetsV2",
             "/private/var/staged_system_apps",
         ]
+        var didEdit = false
         for path in removedPaths {
-            try FileManager.default.removeItem(atPath: mount.appending(path))
+            if FileManager.default.fileExists(atPath: mount.appending(path)) {
+                try FileManager.default.removeItem(atPath: mount.appending(path))
+                didEdit = true
+            }
         }
+        return didEdit
     }
     
     func createTrustcache(filesystem: URL) throws -> URL {

--- a/sources/FirmwarePatcher/Filesystem/CryptexFilesystemPatcher.swift
+++ b/sources/FirmwarePatcher/Filesystem/CryptexFilesystemPatcher.swift
@@ -21,6 +21,20 @@ extension Data {
     var hexString: String {
         self.map { String(format: "%02x", $0) }.joined()
     }
+    
+    init?(fromHexString hex: String) {
+        guard hex.count.isMultiple(of: 2) else {
+            return nil
+        }
+        
+        let chars = hex.map { $0 }
+        let bytes = stride(from: 0, to: chars.count, by: 2)
+            .map { String(chars[$0]) + String(chars[$0 + 1]) }
+            .compactMap { UInt8($0, radix: 16) }
+        
+        guard hex.count / bytes.count == 2 else { return nil }
+        self.init(bytes)
+    }
 }
 
 /// Patcher for the Filesystem payload.
@@ -134,8 +148,8 @@ public final class CryptexFilesystemPatcher: Patcher {
         print("- Finalizing merged image")
         try shrinkImage(dmg: targetImagePath)
         try convertToUDRWImage(input: targetImagePath, output: newDmgPath)
-        let key = try getAeaKey(self.restoreDir.appending(path: osPath))
         let metadata = try getAeaMetadata(self.restoreDir.appending(path: osPath))
+        let key = try getAeaKey(self.restoreDir.appending(path: osPath), metadata: metadata)
         let finalFile = try encryptAeaFile(newDmgPath, key: key, metadata: metadata)
         let finalDestination = self.restoreDir.appending(path: finalFile.lastPathComponent)
         if FileManager.default.fileExists(atPath: finalDestination.path) {
@@ -678,7 +692,17 @@ public final class CryptexFilesystemPatcher: Patcher {
         }
     }
     
-    func getAeaKey(_ path: URL) throws -> String {
+    func getAeaKey(_ path: URL, metadata: [String: String]) throws -> String {
+        if let key = metadata["encryption_key"] {
+            let key = String(key.dropFirst(4))
+            if let unwrapped = Data(fromHexString: key),
+               let encoded = String(data: unwrapped, encoding: .utf8),
+               let data = Data(fromHexString: encoded) {
+                return "base64:\(data.base64EncodedString())"
+            }
+            return key
+        }
+        
         return try runProcess("/opt/homebrew/bin/ipsw", [
             "fw", "aea",
             "--no-color",


### PR DESCRIPTION
This PR contains three patches hardening the use of the patchless variant.

- 815f405aa8e33f56a2d37af4c38ef2bb01af8faa: Adds support for other firmwares that do not contain the extra system paths (excluded from hashing).
- 690c0703e0a8d5bc1c40acdab75bf87fb49224c2: Adds support for firmwares that have the filesystem AEA key embedded in its metadata. The key endpoint returns a 403 for some of these cases.
- a7604d2deef09c30c4413d0badd682257dea403e: Clarifies confusions regarding the `root` statement (we can drop it as the regular variant also requires root for building the Ramdisk.)