### PR TITLE
restore: add offline mode (cached SHSH + in-place AEA decryption)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ help:
 	@echo "Restore:"
 	@echo "  make restore_get_shsh        Dump SHSH response from Apple"
 	@echo "  make restore                 Restore to device (pymobiledevice3 backend)"
+	@echo "  make restore_offline         Restore offline — decrypts AEA images in place, uses cached .shsh blob"
 	@echo ""
 	@echo "Ramdisk:"
 	@echo "  make ramdisk_build           Build signed SSH ramdisk"
@@ -324,19 +325,61 @@ fw_patch_jb: patcher_build
 # Restore
 # ═══════════════════════════════════════════════════════════════════
 
-.PHONY: restore_get_shsh restore
+.PHONY: restore_get_shsh restore restore_offline
+
+# Resolve ECID from RESTORE_ECID or vm/udid-prediction.txt (written by boot_dfu).
+define _resolve_ecid
+	if [ -n "$(RESTORE_ECID)" ]; then \
+		ECID="$(RESTORE_ECID)"; \
+	elif [ -f "$(CURDIR)/$(VM_DIR)/udid-prediction.txt" ]; then \
+		ECID=$$(grep '^ECID=' "$(CURDIR)/$(VM_DIR)/udid-prediction.txt" | head -1 | cut -d= -f2); \
+	fi; \
+	if [ -z "$$ECID" ]; then \
+		echo "[-] Cannot resolve ECID — set RESTORE_ECID or run 'make boot_dfu' first"; \
+		exit 1; \
+	fi
+endef
 
 restore_get_shsh:
-	cd $(VM_DIR) && "$(PYTHON)" "$(PMD3_BRIDGE)" restore-get-shsh \
+	@$(call _resolve_ecid); \
+	cd "$(VM_DIR)" && "$(PYTHON)" "$(PMD3_BRIDGE)" restore-get-shsh \
 		--vm-dir . \
 		$(if $(RESTORE_UDID),--udid $(RESTORE_UDID),) \
-		$(if $(RESTORE_ECID),--ecid $(RESTORE_ECID),)
+		--ecid "$$ECID"
 
 restore:
-	cd $(VM_DIR) && "$(PYTHON)" "$(PMD3_BRIDGE)" restore-update \
+	@$(call _resolve_ecid); \
+	cd "$(VM_DIR)" && "$(PYTHON)" "$(PMD3_BRIDGE)" restore-update \
 		--vm-dir . \
 		$(if $(RESTORE_UDID),--udid $(RESTORE_UDID),) \
-		$(if $(RESTORE_ECID),--ecid $(RESTORE_ECID),)
+		--ecid "$$ECID"
+
+restore_offline:
+	@$(call _resolve_ecid); \
+	SHSH=$$(ls "$(CURDIR)/$(VM_DIR)/"*.shsh 2>/dev/null | head -1); \
+	if [ -z "$$SHSH" ]; then \
+		echo "[-] No .shsh file in $(VM_DIR)/ — run 'make restore_get_shsh' first"; \
+		exit 1; \
+	fi; \
+	RESTORE_SRC=$$(echo "$(CURDIR)/$(VM_DIR)/iPhone"*_Restore); \
+	if [ ! -d "$$RESTORE_SRC" ]; then \
+		echo "[-] No iPhone*_Restore directory in $(VM_DIR)/"; \
+		exit 1; \
+	fi; \
+	echo "[+] Decrypting AEA images in place..."; \
+	for aea in "$$RESTORE_SRC"/*.dmg.aea; do \
+		[ -f "$$aea" ] || continue; \
+		[ "$$(xxd -l 4 -p "$$aea")" = "41454131" ] || continue; \
+		base=$$(basename "$$aea"); \
+		ipsw fw aea -o "$$RESTORE_SRC" "$$aea" 2>/dev/null; \
+		mv -f "$$RESTORE_SRC/$${base%.aea}" "$$aea"; \
+	done; \
+	echo "[+] Restoring offline with SHSH: $$(basename $$SHSH)"; \
+	cd "$(VM_DIR)" && "$(PYTHON)" "$(PMD3_BRIDGE)" restore-update \
+		--vm-dir . \
+		--tss "$$SHSH" \
+		$(if $(RESTORE_UDID),--udid $(RESTORE_UDID),) \
+		--ecid "$$ECID"
 
 # ═══════════════════════════════════════════════════════════════════
 # Ramdisk

--- a/Makefile
+++ b/Makefile
@@ -371,8 +371,18 @@ restore_offline:
 		[ -f "$$aea" ] || continue; \
 		[ "$$(xxd -l 4 -p "$$aea")" = "41454131" ] || continue; \
 		base=$$(basename "$$aea"); \
-		ipsw fw aea -o "$$RESTORE_SRC" "$$aea" 2>/dev/null; \
-		mv -f "$$RESTORE_SRC/$${base%.aea}" "$$aea"; \
+		if ! ipsw fw aea -o "$$RESTORE_SRC" "$$aea"; then \
+			echo "[-] ipsw fw aea failed for $$base — aborting"; \
+			exit 1; \
+		fi; \
+		if ! mv -f "$$RESTORE_SRC/$${base%.aea}" "$$aea"; then \
+			echo "[-] mv failed for $$base — aborting (decrypted file missing?)"; \
+			exit 1; \
+		fi; \
+		if [ "$$(xxd -l 4 -p "$$aea")" = "41454131" ]; then \
+			echo "[-] $$base still AEA1-encrypted after decrypt — aborting"; \
+			exit 1; \
+		fi; \
 	done; \
 	echo "[+] Restoring offline with SHSH: $$(basename $$SHSH)"; \
 	cd "$(VM_DIR)" && "$(PYTHON)" "$(PMD3_BRIDGE)" restore-update \

--- a/scripts/pymobiledevice3_bridge.py
+++ b/scripts/pymobiledevice3_bridge.py
@@ -198,12 +198,23 @@ async def cmd_restore_get_shsh(
     print(f"[+] SHSH saved: {out_path}")
 
 
-async def cmd_restore_update(vm_dir: Path, ecid: Optional[int], udid: Optional[str], erase: bool) -> None:
+async def cmd_restore_update(
+    vm_dir: Path,
+    ecid: Optional[int],
+    udid: Optional[str],
+    erase: bool,
+    tss_path: Optional[Path] = None,
+) -> None:
     restore_dir = find_restore_dir(vm_dir)
     ipsw = IPSW.create_from_path(str(restore_dir))
     behavior = Behavior.Erase if erase else Behavior.Update
     device = await resolve_device(ecid, udid)
-    await Restore(ipsw, device, behavior=behavior, ignore_fdr=False).update()
+    tss = None
+    if tss_path is not None:
+        with tss_path.open("rb") as handle:
+            tss = plistlib.load(handle)
+        print(f"[+] Using cached SHSH: {tss_path}")
+    await Restore(ipsw, device, tss=tss, behavior=behavior, ignore_fdr=False).update()
 
 
 def require_ecid(value: str) -> Optional[int]:
@@ -285,8 +296,15 @@ def restore_update_command(
     ecid: Optional[str] = typer.Option(None, help="Hex ECID (with/without 0x)"),
     udid: Optional[str] = typer.Option(None, help="Target USB UDID"),
     erase: bool = typer.Option(True, "--erase/--no-erase", help="Run update-in-place with --no-erase."),
+    tss: Optional[Path] = typer.Option(
+        None,
+        help="Cached SHSH plist for offline restore (skips Apple TSS request).",
+        exists=False,
+        file_okay=True,
+        dir_okay=False,
+    ),
 ) -> Awaitable[None]:
-    return cmd_restore_update(vm_dir, require_ecid(ecid), udid, erase=erase)
+    return cmd_restore_update(vm_dir, require_ecid(ecid), udid, erase=erase, tss_path=tss)
 
 
 async def main(argv: list[str]) -> None:


### PR DESCRIPTION
## Summary

Adds `make restore_offline` for fully air-gapped restore:

- **`scripts/pymobiledevice3_bridge.py`** — `restore-update` accepts `--tss <path>` and passes a cached SHSH plist as `tss=` to `Restore()`, skipping the live Apple TSS request.
- **`Makefile`** — new `restore_offline` target. Resolves the VM's ECID from `vm/udid-prediction.txt` (or `RESTORE_ECID` override), decrypts each `*.dmg.aea` in place via `ipsw fw aea`, then runs the bridge with `--tss` against `vm/`.
- **`Makefile`** — shared `_resolve_ecid` define applied to all three restore targets (`restore_get_shsh`, `restore`, `restore_offline`) so users don't have to hand-pass `RESTORE_ECID` every invocation.

Implements the `pymobiledevice3 restore update --tss` approach @zqxwce mentioned in #275.

## Why offline matters

`pymobiledevice3` still calls Apple during a normal restore — `Recovery.fetch_tss_record()` hits the TSS server, and `URLAsset` / `StreamedImageDecryptionKey` requests fetch AEA decryption keys mid-restore. `restore_offline` removes both:

- **TSS:** pre-fetched once via `make restore_get_shsh`; reused via `--tss`.
- **AEA keys:** images pre-decrypted with `ipsw fw aea` before the bridge runs.

## Test plan

Verified end-to-end on macOS 15 with a fresh VM:

- [x] `make setup_tools && make build && make vm_new && make fw_prepare && make fw_patch && make boot_dfu`
- [x] `make restore_get_shsh` — wrote `vm/<ECID>.shsh`
- [x] `make restore_offline` — bridge logs `[+] Using cached SHSH: …`, full filesystem transfer (68768/68768) and `verify-restore` (100/100), exit 0
- [x] Re-run idempotent (AEA1 magic check skips already-decrypted files)
- [x] `_resolve_ecid` reads `vm/udid-prediction.txt` cleanly; `RESTORE_ECID=…` still overrides
- [x] No `URLAsset` / `StreamedImage` / `gs.apple` traffic in the bridge logs (full air-gap confirmed)

## Disk cost

In-place decryption adds only the AEA→DMG inflation (~4 GiB on stock iPhone17,3 IPSW) to the existing `vm/iPhone*_Restore/` tree. Re-running is fine; switching back to online `make restore` requires re-running `fw_prepare` to recover the encrypted source images.

## Replaces #275

#275 was the libidevice/idevicerestore-era version (fake TSS server + AEA staging). With pymobiledevice3 the patch collapses to plumbing `--tss` through and decrypting AEA in place — closing #275.

🤖 Generated with [Claude Code](https://claude.com/claude-code)