### PR TITLE
Add missing quote for help option in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ help:
 	@echo "  make setup_machine                   Full setup through First Boot"
 	@echo "    Options: JB=1                      Jailbreak firmware/CFW path"
 	@echo "             DEV=1                     Dev firmware/CFW path (dev TXM + cfw_install_dev)"
-	@echo "             LESS=1                    Build, keeping iOS security mitigations enabled. 
+	@echo "             LESS=1                    Build, keeping iOS security mitigations enabled."
 	@echo "             SKIP_PROJECT_SETUP=1      Skip setup_tools/build"
 	@echo "             NONE_INTERACTIVE=1        Auto-continue prompts + boot analysis"
 	@echo "             SUDO_PASSWORD=...         Preload sudo credential for setup flow"


### PR DESCRIPTION
When running `make help`:
```
vphone-cli — Virtual iPhone boot tool

LazyCat (AIO):
  make setup_machine                   Full setup through First Boot
    Options: JB=1                      Jailbreak firmware/CFW path
             DEV=1                     Dev firmware/CFW path (dev TXM + cfw_install_dev)
/bin/sh: -c: line 0: unexpected EOF while looking for matching `"'
/bin/sh: -c: line 1: syntax error: unexpected end of file
make: *** [help] Error 2
```

This PR adds the missing double-quote.