### PR TITLE
Harden make clean to protect VM and IPSW state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,20 +156,11 @@ clean:
 		echo "WARNING: destructive clean requested."; \
 		[ "$(CLEAN_VM)" = "1" ] && echo "  VM directory: $(VM_DIR)/"; \
 		[ "$(CLEAN_IPSW)" = "1" ] && echo "  IPSW cache:   ipsws/"; \
-	fi; \
-	echo "This removes local build output and dependency/tool caches."; \
-	printf "Continue with clean? [y/N] "; \
-	read answer; \
-	case "$$answer" in y|Y|yes|YES) ;; *) \
-		echo "[-] Clean cancelled; no files removed."; \
-		exit 1; \
-	esac; \
-	if [ "$(CLEAN_VM)" = "1" ] || [ "$(CLEAN_IPSW)" = "1" ]; then \
 		printf "Also remove destructive targets above? [y/N] "; \
 		read answer; \
 		case "$$answer" in y|Y|yes|YES) ;; *) \
 			echo "[-] Destructive clean cancelled; no files removed."; \
-			exit 1; \
+			exit 0; \
 		esac; \
 	fi; \
 	rm -rf .build .swiftpm .vphoned.signed "$(VENV)" "$(TOOLS_PREFIX)"; \

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,9 @@ help:
 	@echo "Build:"
 	@echo "  make build                   Build + sign vphone-cli"
 	@echo "  make vphoned                 Cross-compile + sign vphoned for iOS"
-	@echo "  make clean                   Remove all build artifacts (keeps IPSWs)"
+	@echo "  make clean                   Remove build/tooling artifacts only"
+	@echo "    Options: CLEAN_VM=1        Also remove VM_DIR=$(VM_DIR) after confirmation"
+	@echo "             CLEAN_IPSW=1      Also remove ipsws/ after confirmation"
 	@echo ""
 	@echo "VM management:"
 	@echo "  make vm_new                  Create VM directory with manifest (config.plist)"
@@ -140,13 +142,41 @@ setup_tools:
 	VARIANT=$(VARIANT) zsh $(SCRIPTS)/setup_tools.sh
 
 # ═══════════════════════════════════════════════════════════════════
-# Clean — remove all untracked/ignored files (preserves IPSWs only)
+# Clean — remove generated build/tooling files by default.
+# Destructive VM/IPSW cleanup is opt-in and requires confirmation.
 # ═══════════════════════════════════════════════════════════════════
 
 .PHONY: clean
 clean:
-	@echo "=== Cleaning all untracked files (preserving IPSWs) ==="
-	git clean -fdx -e '*.ipsw' -e '*_Restore*'
+	@set -e; \
+	echo "=== Cleaning build/tooling artifacts ==="; \
+	echo "Removing: .build .swiftpm .vphoned.signed $(VENV) $(TOOLS_PREFIX)"; \
+	if [ "$(CLEAN_VM)" = "1" ] || [ "$(CLEAN_IPSW)" = "1" ]; then \
+		echo ""; \
+		echo "WARNING: destructive clean requested."; \
+		[ "$(CLEAN_VM)" = "1" ] && echo "  VM directory: $(VM_DIR)/"; \
+		[ "$(CLEAN_IPSW)" = "1" ] && echo "  IPSW cache:   ipsws/"; \
+	fi; \
+	echo "This removes local build output and dependency/tool caches."; \
+	printf "Continue with clean? [y/N] "; \
+	read answer; \
+	case "$$answer" in y|Y|yes|YES) ;; *) \
+		echo "[-] Clean cancelled; no files removed."; \
+		exit 1; \
+	esac; \
+	if [ "$(CLEAN_VM)" = "1" ] || [ "$(CLEAN_IPSW)" = "1" ]; then \
+		printf "Also remove destructive targets above? [y/N] "; \
+		read answer; \
+		case "$$answer" in y|Y|yes|YES) ;; *) \
+			echo "[-] Destructive clean cancelled; no files removed."; \
+			exit 1; \
+		esac; \
+	fi; \
+	rm -rf .build .swiftpm .vphoned.signed "$(VENV)" "$(TOOLS_PREFIX)"; \
+	if [ "$(CLEAN_VM)" = "1" ] || [ "$(CLEAN_IPSW)" = "1" ]; then \
+		if [ "$(CLEAN_VM)" = "1" ]; then rm -rf "$(VM_DIR)"; fi; \
+		if [ "$(CLEAN_IPSW)" = "1" ]; then rm -rf ipsws; fi; \
+	fi
 
 # ═══════════════════════════════════════════════════════════════════
 # Build

--- a/README.md
+++ b/README.md
@@ -134,9 +134,9 @@ make fw_patch                 # patch boot chain (regular variant)
 ### Cleaning
 
 ```bash
-make clean                    # asks before removing build/tooling artifacts only
-make clean CLEAN_VM=1         # also remove vm/ after a second confirmation
-make clean CLEAN_IPSW=1       # also remove ipsws/ after a second confirmation
+make clean                    # remove build/tooling artifacts only
+make clean CLEAN_VM=1         # also remove vm/ after confirmation
+make clean CLEAN_IPSW=1       # also remove ipsws/ after confirmation
 ```
 
 Default clean never removes `vm/` or `ipsws/`.

--- a/README.md
+++ b/README.md
@@ -131,6 +131,16 @@ make fw_patch                 # patch boot chain (regular variant)
 # or: make fw_patch_jb        # jailbreak variant (+ full security bypass)
 ```
 
+### Cleaning
+
+```bash
+make clean                    # asks before removing build/tooling artifacts only
+make clean CLEAN_VM=1         # also remove vm/ after a second confirmation
+make clean CLEAN_IPSW=1       # also remove ipsws/ after a second confirmation
+```
+
+Default clean never removes `vm/` or `ipsws/`.
+
 ### VM Configuration
 
 Starting from v1.0, VM configuration is stored in `vm/config.plist`. Set CPU, memory, and disk size during VM creation:

--- a/docs/README_ja.md
+++ b/docs/README_ja.md
@@ -122,9 +122,9 @@ make fw_patch                 # ブートチェーンのパッチ当て（通常
 ### クリーンアップ
 
 ```bash
-make clean                    # 確認後、ビルド/ツール関連の生成物のみ削除
-make clean CLEAN_VM=1         # 2回目の確認後、vm/ も削除
-make clean CLEAN_IPSW=1       # 2回目の確認後、ipsws/ も削除
+make clean                    # ビルド/ツール関連の生成物のみ削除
+make clean CLEAN_VM=1         # 確認後、vm/ も削除
+make clean CLEAN_IPSW=1       # 確認後、ipsws/ も削除
 ```
 
 通常の clean では `vm/` や `ipsws/` は削除されません。

--- a/docs/README_ja.md
+++ b/docs/README_ja.md
@@ -119,6 +119,16 @@ make fw_patch                 # ブートチェーンのパッチ当て（通常
 # または: make fw_patch_jb    # 脱獄バリアント（dev + 完全セキュリティバイパス）
 ```
 
+### クリーンアップ
+
+```bash
+make clean                    # 確認後、ビルド/ツール関連の生成物のみ削除
+make clean CLEAN_VM=1         # 2回目の確認後、vm/ も削除
+make clean CLEAN_IPSW=1       # 2回目の確認後、ipsws/ も削除
+```
+
+通常の clean では `vm/` や `ipsws/` は削除されません。
+
 ### VM 設定
 
 v1.0 から、VM 設定は `vm/config.plist` に保存されます。VM 作成時に CPU、メモリ、ディスクサイズを設定します：

--- a/docs/README_ko.md
+++ b/docs/README_ko.md
@@ -122,9 +122,9 @@ make fw_patch                 # 부트 체인 패치 (일반 변형)
 ### 정리
 
 ```bash
-make clean                    # 확인 후 빌드/도구 산출물만 삭제
-make clean CLEAN_VM=1         # 두 번째 확인 후 vm/ 도 삭제
-make clean CLEAN_IPSW=1       # 두 번째 확인 후 ipsws/ 도 삭제
+make clean                    # 빌드/도구 산출물만 삭제
+make clean CLEAN_VM=1         # 확인 후 vm/ 도 삭제
+make clean CLEAN_IPSW=1       # 확인 후 ipsws/ 도 삭제
 ```
 
 기본 clean은 `vm/` 또는 `ipsws/` 를 삭제하지 않습니다.

--- a/docs/README_ko.md
+++ b/docs/README_ko.md
@@ -119,6 +119,16 @@ make fw_patch                 # 부트 체인 패치 (일반 변형)
 # 또는: make fw_patch_jb      # 탈옥 변형 (dev + 전체 보안 우회)
 ```
 
+### 정리
+
+```bash
+make clean                    # 확인 후 빌드/도구 산출물만 삭제
+make clean CLEAN_VM=1         # 두 번째 확인 후 vm/ 도 삭제
+make clean CLEAN_IPSW=1       # 두 번째 확인 후 ipsws/ 도 삭제
+```
+
+기본 clean은 `vm/` 또는 `ipsws/` 를 삭제하지 않습니다.
+
 ### VM 설정
 
 v1.0부터 VM 설정은 `vm/config.plist`에 저장됩니다. VM 생성 시 CPU, 메모리, 디스크 크기를 설정하세요:

--- a/docs/README_zh.md
+++ b/docs/README_zh.md
@@ -122,9 +122,9 @@ make fw_patch                 # 修补启动链（常规变体）
 ### 清理
 
 ```bash
-make clean                    # 确认后仅删除构建/工具链产物
-make clean CLEAN_VM=1         # 二次确认后同时删除 vm/
-make clean CLEAN_IPSW=1       # 二次确认后同时删除 ipsws/
+make clean                    # 仅删除构建/工具链产物
+make clean CLEAN_VM=1         # 确认后同时删除 vm/
+make clean CLEAN_IPSW=1       # 确认后同时删除 ipsws/
 ```
 
 默认清理不会删除 `vm/` 或 `ipsws/`。

--- a/docs/README_zh.md
+++ b/docs/README_zh.md
@@ -119,6 +119,16 @@ make fw_patch                 # 修补启动链（常规变体）
 # 或：make fw_patch_jb        # 越狱变体（dev + 完整安全绕过）
 ```
 
+### 清理
+
+```bash
+make clean                    # 确认后仅删除构建/工具链产物
+make clean CLEAN_VM=1         # 二次确认后同时删除 vm/
+make clean CLEAN_IPSW=1       # 二次确认后同时删除 ipsws/
+```
+
+默认清理不会删除 `vm/` 或 `ipsws/`。
+
 ### VM 配置
 
 从 v1.0 开始，VM 配置存储在 `vm/config.plist` 中。在创建 VM 时设置 CPU、内存和磁盘大小：


### PR DESCRIPTION
## What changed

- Replaced `make clean`'s broad `git clean -fdx` behavior with explicit removal of:
  - `.build`
  - `.swiftpm`
  - `.vphoned.signed`
  - `.venv`
  - `.tools`
- Added confirmation before normal clean runs.
- Added opt-in destructive cleanup:
  - `CLEAN_VM=1` for `vm/`
  - `CLEAN_IPSW=1` for `ipsws/`
- Added a second confirmation before VM/IPSW deletion.
- Documented clean behavior in English, Chinese, Japanese, and Korean READMEs.

## Why

The previous `make clean` could remove local VM state and other untracked work. That made routine cleanup risky for active vm environments.

## Quick test

- `make -n clean`
- `make -n clean CLEAN_VM=1 CLEAN_IPSW=1`
- Cancelled normal clean and verified no files are removed.
- Cancelled destructive clean and verified no files are removed.
- Accepted VM/IPSW clean in temp dirs and verified only requested targets are removed.
- `git diff --check`