### PR TITLE
Add Scaler Accelerator

### DIFF
--- a/sources/vphone-cli/VPhoneVirtualMachine.swift
+++ b/sources/vphone-cli/VPhoneVirtualMachine.swift
@@ -218,8 +218,10 @@ class VPhoneVirtualMachine: NSObject, VZVirtualMachineDelegate {
         }
         
         if let obj1 = Dynamic._VZMacVideoToolboxDeviceConfiguration().asObject,
-           let obj2 = Dynamic._VZMacNeuralEngineDeviceConfiguration().asObject {
-            Dynamic(config)._setAcceleratorDevices([obj1,obj2])
+           let obj2 = Dynamic._VZMacNeuralEngineDeviceConfiguration().asObject,
+           let obj3 = Dynamic._VZMacScalerAcceleratorDeviceConfiguration().asObject
+        {
+            Dynamic(config)._setAcceleratorDevices([obj1,obj2,obj3])
             print("[vphone] Accelerator devices configured")
         }
 


### PR DESCRIPTION
Related to #306

We found that the vphone600 supports the Scaler Accelerator.

We have not analysed the exact usage of this accelerator. However, we think that it is used transparently for graphics accelerations, such as the Neural Engine Accelerator is used transparently by the Core ML framework.