### PR TITLE
cfw_install: handle pre-decrypted DMGs from restore_offline

### DIFF
--- a/scripts/cfw_install.sh
+++ b/scripts/cfw_install.sh
@@ -303,13 +303,20 @@ else
     MNT_SYSOS="$TEMP_DIR/mnt_sysos"
     MNT_APPOS="$TEMP_DIR/mnt_appos"
 
-    # Decrypt SystemOS AEA (cached — skip if already decrypted)
+    # Decrypt SystemOS AEA (cached — skip if already decrypted).
+    # `make restore_offline` decrypts .dmg.aea files in place, keeping the .aea
+    # filename, so the BuildManifest path may already point to a raw DMG.
     if [[ ! -f "$SYSOS_DMG" ]]; then
-        echo "  Extracting AEA key..."
-        AEA_KEY=$(ipsw fw aea --key "$RESTORE_DIR/$CRYPTEX_SYSOS")
-        echo "  key: $AEA_KEY"
-        echo "  Decrypting SystemOS..."
-        aea decrypt -i "$RESTORE_DIR/$CRYPTEX_SYSOS" -o "$SYSOS_DMG" -key-value "$AEA_KEY"
+        if [[ "$(xxd -l 4 -p "$RESTORE_DIR/$CRYPTEX_SYSOS")" == "41454131" ]]; then
+            echo "  Extracting AEA key..."
+            AEA_KEY=$(ipsw fw aea --key "$RESTORE_DIR/$CRYPTEX_SYSOS")
+            echo "  key: $AEA_KEY"
+            echo "  Decrypting SystemOS..."
+            aea decrypt -i "$RESTORE_DIR/$CRYPTEX_SYSOS" -o "$SYSOS_DMG" -key-value "$AEA_KEY"
+        else
+            echo "  SystemOS already decrypted in place (no AEA1 magic), copying..."
+            cp "$RESTORE_DIR/$CRYPTEX_SYSOS" "$SYSOS_DMG"
+        fi
     else
         echo "  Using cached SystemOS DMG"
     fi

--- a/scripts/cfw_install_dev.sh
+++ b/scripts/cfw_install_dev.sh
@@ -242,13 +242,20 @@ APPOS_DMG="$TEMP_DIR/CryptexAppOS.dmg"
 MNT_SYSOS="$TEMP_DIR/mnt_sysos"
 MNT_APPOS="$TEMP_DIR/mnt_appos"
 
-# Decrypt SystemOS AEA (cached — skip if already decrypted)
+# Decrypt SystemOS AEA (cached — skip if already decrypted).
+# `make restore_offline` decrypts .dmg.aea files in place, keeping the .aea
+# filename, so the BuildManifest path may already point to a raw DMG.
 if [[ ! -f "$SYSOS_DMG" ]]; then
-    echo "  Extracting AEA key..."
-    AEA_KEY=$(ipsw fw aea --key "$RESTORE_DIR/$CRYPTEX_SYSOS")
-    echo "  key: $AEA_KEY"
-    echo "  Decrypting SystemOS..."
-    aea decrypt -i "$RESTORE_DIR/$CRYPTEX_SYSOS" -o "$SYSOS_DMG" -key-value "$AEA_KEY"
+    if [[ "$(xxd -l 4 -p "$RESTORE_DIR/$CRYPTEX_SYSOS")" == "41454131" ]]; then
+        echo "  Extracting AEA key..."
+        AEA_KEY=$(ipsw fw aea --key "$RESTORE_DIR/$CRYPTEX_SYSOS")
+        echo "  key: $AEA_KEY"
+        echo "  Decrypting SystemOS..."
+        aea decrypt -i "$RESTORE_DIR/$CRYPTEX_SYSOS" -o "$SYSOS_DMG" -key-value "$AEA_KEY"
+    else
+        echo "  SystemOS already decrypted in place (no AEA1 magic), copying..."
+        cp "$RESTORE_DIR/$CRYPTEX_SYSOS" "$SYSOS_DMG"
+    fi
 else
     echo "  Using cached SystemOS DMG"
 fi


### PR DESCRIPTION
## Summary

`make restore_offline` (added in #311) decrypts `.dmg.aea` cryptex
images in place — it `mv`s the decrypted DMG back over the original
`.aea` filename so the BuildManifest path keeps working. However,
`cfw_install.sh` and `cfw_install_dev.sh` then unconditionally call
`ipsw fw aea --key` on that same path, which fails because the file
no longer has the `AEA1` magic:

    ⨯ failed to parse AEA: invalid AEA header: found '...' expected 'AEA1'

This patch checks the first 4 bytes for the `AEA1` magic before
invoking `ipsw fw aea` / `aea decrypt`. When the file is already a
raw DMG (post-`restore_offline`), it's copied straight to the cached
`CryptexSystemOS.dmg` instead.

## Repro

1. `make restore_offline` (decrypts AEA images in place)
2. `make cfw_install_jb` (or `cfw_install` / `cfw_install_dev`)
3. Fails at the "Extracting AEA key..." step

🤖 Generated with [Claude Code](https://claude.com/claude-code)