### PR TITLE
Cryptex Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,7 @@ help:
 	@echo "Restore:"
 	@echo "  make restore_get_shsh        Dump SHSH response from Apple"
 	@echo "  make restore                 Restore to device (pymobiledevice3 backend)"
+	@echo "  make restore_mobiledevice    Restore to device (MobileDevice backend)"
 	@echo "  make restore_offline         Restore offline — decrypts AEA images in place, uses cached .shsh blob"
 	@echo ""
 	@echo "Ramdisk:"
@@ -388,6 +389,12 @@ restore:
 		--vm-dir . \
 		$(if $(RESTORE_UDID),--udid $(RESTORE_UDID),) \
 		--ecid "$$ECID"
+
+restore_mobiledevice: bundle
+	cd $(VM_DIR) && "$(CURDIR)/$(BUNDLE_BIN)" \
+	    restore \
+		--config ./config.plist \
+		--ipsw "iPhone"*
 
 restore_offline:
 	@$(call _resolve_ecid); \

--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,7 @@ let package = Package(
                 .product(name: "Capstone", package: "libcapstone-spm"),
                 .product(name: "Img4tool", package: "libimg4-spm"),
                 .product(name: "MachOKit", package: "MachOKit"),
+                "MobileDevice"
             ],
             path: "sources/FirmwarePatcher"
         ),
@@ -40,6 +41,14 @@ let package = Package(
                 .linkedFramework("CoreLocation"),
                 .linkedFramework("AVFoundation"),
             ]
+        ),
+        .target(
+            name: "MobileDevice",
+            path: "sources/MobileDevice",
+            linkerSettings: [
+                .unsafeFlags(["-F", "/Library/Apple/System/Library/PrivateFrameworks/"]),
+                .linkedFramework("MobileDevice")
+            ],
         ),
         .testTarget(
             name: "FirmwarePatcherTests",

--- a/scripts/fw_manifest.py
+++ b/scripts/fw_manifest.py
@@ -193,7 +193,7 @@ def main():
         "ManifestVersion": cloudos_bm["ManifestVersion"],
         "ProductBuildVersion": cloudos_bm["ProductBuildVersion"],
         "ProductVersion": cloudos_bm["ProductVersion"],
-        "SupportedProductTypes": ["iPhone99,11"],
+        "SupportedProductTypes": ["iPhone99,11", "ComputeModule14,2"],
     }
 
     # ── Assemble Restore.plist ───────────────────────────────────────
@@ -213,10 +213,7 @@ def main():
             )
             for cat in ("DFU", "Recovery")
         },
-        "SupportedProductTypes": (
-            iphone_rp.get("SupportedProductTypes", [])
-            + cloudos_rp.get("SupportedProductTypes", [])
-        ),
+        "SupportedProductTypes": build_manifest["SupportedProductTypes"],
         "SystemRestoreImageFileSystems": copy.deepcopy(
             iphone_rp["SystemRestoreImageFileSystems"]
         ),

--- a/scripts/fw_prepare.sh
+++ b/scripts/fw_prepare.sh
@@ -411,6 +411,30 @@ extract() {
     cp -R "$cache" "$out"
 }
 
+extract_cryptexctl() {
+    local cloudOS="$1"
+    
+    local project_dir="$(cd "$SCRIPT_DIR/.." && pwd)"
+    local tools_prefix="$project_dir/.tools"
+    local tmp_dir="$(mktemp -d)"
+    
+    local aea_path="$(/usr/bin/plutil -extract 'BuildIdentities.0.Manifest.OS.Info.Path' raw -o - "$cloudOS/BuildManifest.plist")"
+    if [ -z "$aea_path" ]; then
+      echo "Failed to read cloudOS OS path from BuildManifest"
+      rm -rf "$tmp_dir"
+      exit 1
+    fi
+    
+    local disk_dir="$tmp_dir/decrypted"
+    ipsw fw aea --output "$disk_dir" "$cloudOS/$aea_path"
+    local disk=$(ls -AU $disk_dir | head -1)
+
+    local mount="$(hdiutil attach -readonly -nobrowse "$disk_dir/$disk" | awk 'END{ print$NF}')"
+    cp "$mount/usr/bin/cryptexctl" "$tools_prefix/cryptexctl"
+    hdiutil detach "$mount" >/dev/null 2>&1 || true
+    rm -rf "$tmp_dir"
+}
+
 download_apfs_sealvolume() {
     local src="$1"
     local base ios_version filename PROJECT_DIR TOOLS_PREFIX TMP_DIR bn ver BUILD BUILD_MANIFEST RAMDISK_PATH RAMDISK_IM4P RAMDISK MOUNT
@@ -643,6 +667,9 @@ CLOUDOS_CACHE="${IPSW_DIR}/${CLOUDOS_DIR}"
 
 extract "$IPHONE_IPSW_PATH" "$IPHONE_CACHE" "$IPHONE_DIR"
 extract "$CLOUDOS_IPSW_PATH" "$CLOUDOS_CACHE" "$CLOUDOS_DIR"
+
+echo "==> Extracting cryptexctl"
+extract_cryptexctl "$CLOUDOS_DIR"
 
 # Keep exactly one active restore tree in the working directory so fw_patch
 # cannot accidentally pick a stale older firmware directory.

--- a/scripts/setup_machine.sh
+++ b/scripts/setup_machine.sh
@@ -1076,9 +1076,15 @@ main() {
   load_device_identity
   wait_for_recovery
   run_make "Restore" restore_get_shsh RESTORE_UDID="$DEVICE_UDID" RESTORE_ECID="0x$DEVICE_ECID"
-  run_make "Restore" restore RESTORE_UDID="$DEVICE_UDID" RESTORE_ECID="0x$DEVICE_ECID"
-  wait_for_post_restore_reboot
-  stop_boot_dfu
+  
+  # The MobileDevice restore (for Cryptex support) is currently only activated for the Patchless mode.
+  if [[ "$LESS_MODE" -eq 0 ]]; then
+    run_make "Restore" restore RESTORE_UDID="$DEVICE_UDID" RESTORE_ECID="0x$DEVICE_ECID"
+    wait_for_post_restore_reboot
+    stop_boot_dfu
+  else
+    run_make "Restore" restore_mobiledevice
+  fi
 
   if [[ "$LESS_MODE" -eq 0 ]]; then
     echo "[*] Waiting ${POST_KILL_SETTLE_DELAY}s for cleanup before ramdisk stage..."

--- a/scripts/vphoned/vphoned.m
+++ b/scripts/vphoned/vphoned.m
@@ -27,6 +27,7 @@
 #import "vphoned_accessibility.h"
 #import "vphoned_apps.h"
 #import "vphoned_clipboard.h"
+#import "vphoned_cryptex.h"
 #import "vphoned_devmode.h"
 #import "vphoned_files.h"
 #import "vphoned_hid.h"
@@ -326,6 +327,8 @@ static BOOL handle_client(int fd) {
       [caps addObject:@"ipa_install"];
     if (gClipboardAvailable)
       [caps addObject:@"clipboard"];
+    if (vp_cryptex_available())
+      [caps addObject:@"cryptex"];
     if (gAppsAvailable)
       [caps addObject:@"apps"];
     [caps addObject:@"url"];
@@ -393,6 +396,14 @@ static BOOL handle_client(int fd) {
         // Clipboard operations (need fd for inline binary transfer)
         if ([t hasPrefix:@"clipboard_"]) {
           NSDictionary *resp = vp_handle_clipboard_command(fd, msg);
+          if (resp && !vp_write_message(fd, resp))
+            break;
+          continue;
+        }
+
+        // Cryptex operations (need fd for inline binary transfer)
+        if ([t hasPrefix:@"cryptex_"]) {
+          NSDictionary *resp = vp_handle_cryptex_command(msg);
           if (resp && !vp_write_message(fd, resp))
             break;
           continue;

--- a/scripts/vphoned/vphoned_cryptex.h
+++ b/scripts/vphoned/vphoned_cryptex.h
@@ -1,0 +1,13 @@
+/*
+ * vphoned_cryptex — Cryptex install over vsock.
+ *
+ */
+
+#pragma once
+#import <Foundation/Foundation.h>
+
+BOOL vp_cryptex_available(void);
+
+/// Handle a cryptex command. Returns a response dict, or nil if the response
+/// was already written inline (e.g. file_get with streaming data).
+NSDictionary *vp_handle_cryptex_command(NSDictionary *msg);

--- a/scripts/vphoned/vphoned_cryptex.m
+++ b/scripts/vphoned/vphoned_cryptex.m
@@ -1,0 +1,221 @@
+/*
+ * vphoned_cryptex — Cryptex install over vsock.
+ *
+ */
+
+#import <Foundation/Foundation.h>
+#import <spawn.h>
+#import <sys/wait.h>
+
+#import "vphoned_cryptex.h"
+#import "vphoned_protocol.h"
+#import "unarchive.h"
+
+// We currently rely on the /usr/bin/cryptexctl executable (present in the cloudOS filesystem).
+// In future, we can replace this dependency, by directly using the (Swift) CryptexKit framework.
+BOOL vp_cryptex_available(void) {
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    return [fileManager fileExistsAtPath:@"/usr/bin/cryptexctl"];
+}
+
+
+extern char **environ;
+
+typedef NS_ENUM(NSInteger, CryptexErrorCode) {
+    CryptexErrorCodeStreamOpenFailure = 1,
+    CryptexErrorCodeIOError,
+    CryptexErrorCodePersonalizationFailed,
+    CryptexErrorCodeNonZeroExit
+};
+
+static NSString * const CryptexErrorDomain = @"CryptexErrorDomain";
+
+static NSError *CryptexMakeError(CryptexErrorCode code, NSString *description, NSDictionary * _Nullable userInfo)
+{
+    NSMutableDictionary *info = [NSMutableDictionary dictionary];
+    info[NSLocalizedDescriptionKey] = description;
+    if (userInfo.count > 0) {
+        [info addEntriesFromDictionary:userInfo];
+    }
+    return [NSError errorWithDomain:CryptexErrorDomain code:code userInfo:info];
+}
+
+static BOOL RunExecutable(const char *executable, const char *const *arguments,
+                          NSString * _Nullable *stdoutString) {
+    
+    int pipefd[2];
+    if (pipe(pipefd) != 0) {
+        return NO;
+    }
+    posix_spawn_file_actions_t actions;
+    posix_spawn_file_actions_init(&actions);
+    posix_spawn_file_actions_adddup2(&actions, pipefd[1], STDOUT_FILENO);
+    posix_spawn_file_actions_adddup2(&actions, pipefd[1], STDERR_FILENO);
+    posix_spawn_file_actions_addclose(&actions, pipefd[0]);
+    posix_spawn_file_actions_addclose(&actions, pipefd[1]);
+    
+    pid_t pid;
+    int status;
+
+    int result = posix_spawn(&pid,
+                             executable,
+                             &actions,
+                             NULL,
+                             (char *const *)arguments,
+                             environ);
+
+    posix_spawn_file_actions_destroy(&actions);
+    close(pipefd[1]);
+    
+    if (result != 0) {
+        close(pipefd[0]);
+        return NO;
+    }
+    
+    NSMutableData *data = [NSMutableData data];
+    char buffer[4096];
+    ssize_t n;
+    while ((n = read(pipefd[0], buffer, sizeof(buffer))) > 0) {
+        [data appendBytes:buffer length:(NSUInteger)n];
+    }
+    close(pipefd[0]);
+
+    if (stdoutString) {
+        *stdoutString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+    }
+    
+    if (waitpid(pid, &status, 0) == -1) {
+        return NO;
+    }
+
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        return NO;
+    }
+
+    return YES;
+}
+
+BOOL ExtractCryptex(NSString *archivePath, NSString *target, NSString * _Nullable *output)
+{
+    NSString *archiveError = nil;
+    int ret = vp_extract_archive(archivePath, target, &archiveError);
+    if (ret != 0) {
+        *output = [@"Extraction issue" stringByAppendingString:archiveError];
+        return NO;
+    }
+    return YES;
+}
+
+BOOL PersonalizeCryptex(NSString *uncompressedPath,
+                        NSString *variant,
+                        NSString * _Nullable * _Nullable personalizedPath,
+                        NSString * _Nullable *output)
+{
+    NSString *outputPath = [uncompressedPath stringByAppendingString:@".signed"];
+    BOOL ok = [[NSFileManager defaultManager] createDirectoryAtPath:outputPath withIntermediateDirectories:YES attributes:nil error:nil];
+    
+    NSArray<NSString *> *contents = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:uncompressedPath error:nil];
+    for (NSString *name in contents) {
+        NSString *path = [uncompressedPath stringByAppendingPathComponent:name];
+
+        const char *args[] = {
+            "cryptexctl",
+            "personalize",
+            "--variant", [variant UTF8String],
+            "--replace",
+            "--host-identity",
+            "--output-directory", [outputPath UTF8String],
+            [path UTF8String],
+            NULL
+        };
+        BOOL ok = RunExecutable("/usr/bin/cryptexctl", args, output);
+        if (!ok) {
+            return NO;
+        }
+        
+        NSArray<NSString *> *contents = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:outputPath error:nil];
+        for (NSString *name in contents) {
+            NSString *signedPath = [outputPath stringByAppendingPathComponent:name];
+            *personalizedPath = signedPath;
+            return YES;
+        }
+        *output = @"Signed Cryptex not found";
+        return NO;
+    }
+    *output = @"No subdir";
+    return NO;
+}
+
+BOOL InstallCryptex(NSString *cryptexPath, NSString *variant, NSString * _Nullable *output)
+{
+    const char *args[] = {
+        "cryptexctl",
+        "install",
+        "--variant", [variant UTF8String],
+        "--print-info",
+        [cryptexPath UTF8String],
+        NULL
+    };
+
+    return RunExecutable("/usr/bin/cryptexctl", args, output);
+}
+
+BOOL HandleCryptex(NSString *archivePath, NSString *variant, NSString * _Nullable *output)
+{
+    NSString *parentDir = [archivePath stringByDeletingLastPathComponent];
+    NSString *fileName = [archivePath lastPathComponent];
+
+    NSString *extractedDir =
+        [parentDir stringByAppendingPathComponent:
+            [fileName stringByAppendingString:@"-extracted"]];
+
+    NSError *error = nil;
+    BOOL ok = [[NSFileManager defaultManager] createDirectoryAtPath:extractedDir withIntermediateDirectories:YES attributes:nil error:&error];
+    if (!ok) {
+        *output = [@"Failed to create directory:" stringByAppendingString: [error localizedDescription]];
+        return NO;
+    }
+
+    if (!ExtractCryptex(archivePath, extractedDir, output)) {
+        return NO;
+    }
+
+    NSString *personalizedPath = nil;
+    if (!PersonalizeCryptex(extractedDir, variant, &personalizedPath, output)) {
+        return NO;
+    }
+
+    if (!InstallCryptex(personalizedPath, variant, output)) {
+        return NO;
+    }
+    return YES;
+}
+
+
+NSDictionary *vp_handle_cryptex_command(NSDictionary *msg) {
+    NSString *type = msg[@"t"];
+    id reqId = msg[@"id"];
+    NSMutableDictionary *r = vp_make_response(@"err", reqId);
+
+    if ([type isEqualToString:@"cryptex_install"]) {
+        NSString *archivePath = msg[@"path"];
+        NSString *variant = msg[@"variant"];
+
+        NSString *output = nil;
+        BOOL success = HandleCryptex(archivePath, variant, &output);
+
+        r[@"msg"] = output;
+        r[@"ok"] = @(success);
+        return r;
+    } else if ([type isEqualToString:@"cryptex_list"]) {
+        NSString *output = @"";
+        const char *args[] = { "cryptexctl", "list", NULL };
+        RunExecutable("/usr/bin/cryptexctl", args, &output);
+        r[@"msg"] = output;
+        r[@"ok"] = @(YES);
+        return r;
+    }
+
+    r[@"msg"] = [NSString stringWithFormat:@"unknown cryptex command: %@", type];
+    return r;
+}

--- a/sources/FirmwarePatcher/Filesystem/CryptexFilesystemPatcher.swift
+++ b/sources/FirmwarePatcher/Filesystem/CryptexFilesystemPatcher.swift
@@ -523,15 +523,13 @@ public final class CryptexFilesystemPatcher: Patcher {
         let (device, mount) = try attachImage(path: filesystem, readonly: true)
         defer { try? detachImage(deviceNode: device) }
         
-        let oldTrustcache = try getTrustcachePath()
-        let oldTrustcachePath = self.restoreDir.appending(path: oldTrustcache)
         let newTrustcachePath = self.restoreDir.appending(path: "Firmware/new.trustcache")
         let tmpDir = try createTmpDir()
         
         let tcContainer = tmpDir.appending(path: "new.trustcache")
         _ = try runProcess("/System/Library/SecurityResearch/usr/bin/cryptexctl", [
             "generate-trust-cache", "--type", "static",
-            "--base-trust-cache", oldTrustcachePath.path,
+            "--restricted-exec-mode-default", "both",
             "--output-file", tcContainer.path,
             mount
         ])

--- a/sources/FirmwarePatcher/Filesystem/CryptexFilesystemPatcher.swift
+++ b/sources/FirmwarePatcher/Filesystem/CryptexFilesystemPatcher.swift
@@ -100,6 +100,7 @@ public final class CryptexFilesystemPatcher: Patcher {
         // update trustcache, metadata, root_hash path
         let updatedManifest = try setUpdatedComponentsInManifest(filesystem: aeaImage, trustcache: trustcachePath, metadata: metadataPath, rootHash: rootHashContainer)
         rebuiltData = try serializePayload(updatedManifest)
+        try setUpdatedComponentsInRestorePlist(filesystem: aeaImage)
         
         return 1
     }
@@ -568,6 +569,19 @@ public final class CryptexFilesystemPatcher: Patcher {
             format: .xml,
             options: 0
         )
+    }
+    
+    func setUpdatedComponentsInRestorePlist(filesystem: URL) throws {
+        let path = self.restoreDir.appending(path: "Restore.plist")
+        let data = try Data.init(contentsOf: path)
+        guard let pathSuffix = relativePath(from: filesystem, base: self.restoreDir.appendingPathComponent("", isDirectory: true)) else {
+            throw FirmwareManifest.ManifestError.fileNotFound("path suffix for \(filesystem)")
+        }
+        var root = try parsePlist(data: data)
+        let newdict: PlistDict = [ pathSuffix: "APFS" ]
+        root["SystemRestoreImageFileSystems"] = newdict
+        let newData = try serializePayload(root)
+        try newData.write(to: path)
     }
     
     func setUpdatedComponentsInManifest(filesystem: URL, trustcache: URL, metadata: URL, rootHash: URL) throws -> PlistDict {

--- a/sources/FirmwarePatcher/Filesystem/CryptexFilesystemPatcher.swift
+++ b/sources/FirmwarePatcher/Filesystem/CryptexFilesystemPatcher.swift
@@ -115,6 +115,7 @@ public final class CryptexFilesystemPatcher: Patcher {
     func mergeFilesystems() throws -> (URL, URL) {
         let osPath = try getOSFilesystemPath()
         let osDmgPath = try decryptAeaFile(self.restoreDir.appending(path: osPath))
+        defer { try? FileManager.default.removeItem(at: osDmgPath) }
         let tmpDir = try createTmpDir()
         let newDmgPath = tmpDir.appending(path: "new-filesystem.dmg")
         
@@ -568,6 +569,7 @@ public final class CryptexFilesystemPatcher: Patcher {
         } else {
             try decryptAeaFile(self.restoreDir.appending(path: try getSystemOsFilesystemPath()))
         }
+        defer { if !appOS { try? FileManager.default.removeItem(at: osPath) } }
         let (osDevice, osMount) = try attachImage(path: osPath, readonly: true)
         defer { try? detachImage(deviceNode: osDevice) }
         

--- a/sources/FirmwarePatcher/Filesystem/CryptexFilesystemPatcher.swift
+++ b/sources/FirmwarePatcher/Filesystem/CryptexFilesystemPatcher.swift
@@ -119,7 +119,9 @@ public final class CryptexFilesystemPatcher: Patcher {
         let newDmgPath = tmpDir.appending(path: "new-filesystem.dmg")
         
         print("- Converting OS image")
-        let targetImagePath = tmpDir.appending(path: "disk.dmg")
+        // Resizing is very limited in a temporary directory
+        let targetImagePath = self.restoreDir.appending(path: "disk.dmg")
+        defer { try? FileManager.default.removeItem(at: targetImagePath) }
         do {
             try convertToRawImage(input: osDmgPath, output: targetImagePath)
             let (targetDevice, targetMount) = try attachImage(path: targetImagePath, forceRW: true)
@@ -158,6 +160,9 @@ public final class CryptexFilesystemPatcher: Patcher {
                 try injectLaunchDaemons(targetMount: targetMount, cfwInput: cfwInputPath, vphoned: !noVphoned, cfw: !noBinpack)
                 try patchLaunchdCacheLoader(targetMount: targetMount, cfwInput: cfwInputPath)
             }
+            
+            print("- Add cryptexctl")
+            try addCryptexctl(targetMount: targetMount)
         }
         
         print("- Finalizing merged image")
@@ -230,6 +235,17 @@ public final class CryptexFilesystemPatcher: Patcher {
         ])
         try FileManager.default.moveItem(at: launchdPath, to: launchdOgPath)
         _ = try runProcess("/bin/chmod", ["0644", launchdOgPath.path])
+    }
+    
+    func addCryptexctl(targetMount: String) throws {
+        let cryptexctl = self.vphoneCliDirectory.appending(path: ".tools/cryptexctl")
+        guard FileManager.default.fileExists(atPath: cryptexctl.path) else {
+            print("cryptexctl not present")
+            return
+        }
+        
+        let target = URL(fileURLWithPath: targetMount).appending(path: "/usr/bin/cryptexctl")
+        try FileManager.default.copyItem(atPath: cryptexctl.path, toPath: target.path)
     }
     
     func addExtraServices(targetMount: String, cfwInput: URL) throws {

--- a/sources/MobileDevice/MobileDevice.m
+++ b/sources/MobileDevice/MobileDevice.m
@@ -1,0 +1,1 @@
+// MobileDevice needs at least one source file to be valid.

--- a/sources/MobileDevice/include/MobileDevice.h
+++ b/sources/MobileDevice/include/MobileDevice.h
@@ -1,0 +1,86 @@
+//
+//  MobileDevice.h
+//  MobileDevice
+//
+//  An interface to the private API of MobileDevice.framework.
+//
+
+#ifndef MobileDevice_h
+#define MobileDevice_h
+
+#include <CoreFoundation/CoreFoundation.h>
+
+
+// MARK: Structures
+
+typedef enum {
+    kAMRestorableDeviceEventDiscovered,
+    kAMRestorableDeviceEventDisappeared
+} AMRestorableDeviceEvent;
+
+typedef enum {
+    kAMRestorableDeviceStateUnknown,
+    kAMRestorableDeviceStateDFU = 16777217,
+    kAMRestorableDeviceStateDFUMac = 16777218,
+    kAMRestorableDeviceStateRecovery,
+    kAMRestorableDeviceStateRestoreOS,
+    kAMRestorableDeviceStateBootedOS,
+    kAMRestorableDeviceStateRamrodOS,
+    kAMRestorableDeviceStatePortDFU
+} AMRestorableDeviceState;
+
+typedef struct __AMRestorableDevice* AMRestorableDeviceRef;
+typedef struct _AMDevice *AMDeviceRef;
+typedef int AMDError;
+typedef int AMRestorableClientID;
+typedef void (*AMRestorableDeviceEventCallback)( AMRestorableDeviceRef device, AMRestorableDeviceEvent event, void *context );
+typedef void (*AMRestorableDeviceProgressUpdateCallback)( AMRestorableDeviceRef device, CFDictionaryRef info, void *context );
+
+
+// MARK: Constants
+
+#define kAMRestoreOptionsRestoreBootArgs CFSTR("RestoreBootArgs")
+#define kAMRestoreOptionsPostRestoreAction CFSTR("PostRestoreAction")
+#define kAMRestorePostRestoreShutdown CFSTR("Shutdown")
+#define kAMRestorableRestoreOptionWaitForDeviceConnectionToFinishStateMachine CFSTR("WaitForDeviceConnectionToFinishStateMachine")
+#define kAMRestoreOptionsPersistentBootArgModifications CFSTR("PersistantBootArgsModifications")
+#define kAMRestoreBootArgsAdd CFSTR("Add")
+#define kAMRestoreOptionsRestoreBundlePath CFSTR("RestoreBundlePath")
+#define kAMRestoreOptionsAuthInstallVariant CFSTR("AuthInstallVariant")
+#define kAMRestorableDeviceInfoKeyOverallProgress CFSTR("Overall Progress")
+#define kAMRestorableDeviceInfoKeyStatus CFSTR("Status")
+#define kAMRestorableDeviceStatusRestoring CFSTR("Restoring")
+#define kAMRestorableDeviceStatusSuccessful CFSTR("Successful")
+#define kAMRestorableDeviceInfoKeyError CFSTR("Error")
+
+extern const AMRestorableClientID kAMRestorableInvalidClientID;
+extern const char kAMRestorableDeviceStateVersion2;
+
+
+
+// MARK: Functions
+
+CFMutableDictionaryRef AMRestorableDeviceCopyDefaultRestoreOptions( void ) CF_RETURNS_RETAINED;
+AMRestorableClientID AMRestorableDeviceRegisterForNotifications( AMRestorableDeviceEventCallback eventHandler,
+                                                                         void *context,
+                                                                         CFErrorRef *error );
+bool AMRestorableDeviceUnregisterForNotifications(AMRestorableClientID clientID );
+AMDError AMDeviceEnterRecovery( AMDeviceRef device );
+void AMRestorableDeviceStartWatchingSerialLog( AMRestorableDeviceRef device );
+void AMRestorableDeviceStopWatchingSerialLog( AMRestorableDeviceRef device );
+void AMRestorableDeviceRestore( AMRestorableDeviceRef device,
+                                        CFDictionaryRef options,
+                                        AMRestorableDeviceProgressUpdateCallback progressHandler,
+                                        void *context );
+AMRestorableDeviceState AMRestorableDeviceGetStateWithVersion( AMRestorableDeviceRef aDevice, id version );
+bool AMRestorableDeviceSetLogFileURL( AMRestorableDeviceRef aDevice, CFURLRef fileURL, CFStringRef logType );
+
+
+
+static inline const void *getAMRestorableDeviceStateVersion2(void)
+{
+    return (const void *)&kAMRestorableDeviceStateVersion2;
+}
+
+
+#endif /* MobileDevice_h */

--- a/sources/vphone-cli/VPhoneAppDelegate.swift
+++ b/sources/vphone-cli/VPhoneAppDelegate.swift
@@ -156,6 +156,7 @@ class VPhoneAppDelegate: NSObject, NSApplicationDelegate {
             control.onConnect = { [weak mc, weak provider = locationProvider] caps in
                 mc?.updateConnectAvailability(available: true)
                 mc?.updateInstallAvailability(available: caps.contains("ipa_install"))
+                mc?.updateCryptexAvailability(available: caps.contains("cryptex"))
                 mc?.updateAppsAvailability(available: caps.contains("apps"))
                 mc?.updateURLAvailability(available: caps.contains("url"))
                 mc?.updateClipboardAvailability(available: caps.contains("clipboard"))
@@ -178,6 +179,7 @@ class VPhoneAppDelegate: NSObject, NSApplicationDelegate {
             control.onDisconnect = { [weak mc, weak provider = locationProvider] in
                 mc?.updateConnectAvailability(available: false)
                 mc?.updateInstallAvailability(available: false)
+                mc?.updateCryptexAvailability(available: false)
                 mc?.updateAppsAvailability(available: false)
                 mc?.updateURLAvailability(available: false)
                 mc?.updateClipboardAvailability(available: false)

--- a/sources/vphone-cli/VPhoneCLI.swift
+++ b/sources/vphone-cli/VPhoneCLI.swift
@@ -7,6 +7,7 @@ import Virtualization
 
 
 enum CLIError: Error {
+    case CryptexError(String)
     case RestoreError(String)
 }
 
@@ -14,7 +15,7 @@ struct VPhoneCLI: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "vphone-cli",
         abstract: "Boot a virtual iPhone or patch firmware with the Swift pipeline",
-        subcommands: [VPhoneBootCLI.self, VPhoneRestoreCLI.self, PatchFirmwareCLI.self, PatchComponentCLI.self],
+        subcommands: [VPhoneBootCLI.self, VPhoneRestoreCLI.self, PatchFirmwareCLI.self, PatchComponentCLI.self, CryptexCLI.self],
         defaultSubcommand: VPhoneBootCLI.self
     )
 }
@@ -485,5 +486,34 @@ struct PatchComponentCLI: ParsableCommand {
             print("[patch-component] applied \(count) patches for \(component.rawValue)")
             print("[patch-component] wrote patched payload to \(output.path)")
         }
+    }
+}
+
+struct CryptexCLI: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "cryptex",
+        abstract: "Configure the use of Cryptexes for your virtual iPhone",
+        subcommands: [CryptexCreateCLI.self]
+    )
+}
+
+struct CryptexCreateCLI: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "create",
+        abstract: "Create a cryptex to your virtual iPhone"
+    )
+    
+    @Option(name: [.customLong("source"), .customShort("s")],
+            help: "The source for compiling the Cryptex. Required.")
+    var path: String
+    
+    @Option(name: [.customLong("variant"), .customShort("v")],
+            help: "The variant of the referenced Cryptex (research, release, ...). Required.")
+    var variant: String
+
+    mutating func run() throws {
+        print("Creating cryptex")
+        let path = try Cryptex.createCryptex(source: path, name: variant)
+        print("Created cryptex at \(path)")
     }
 }

--- a/sources/vphone-cli/VPhoneCLI.swift
+++ b/sources/vphone-cli/VPhoneCLI.swift
@@ -1,12 +1,20 @@
 import ArgumentParser
 import FirmwarePatcher
 import Foundation
+import MobileDevice
+import Dynamic
+import Virtualization
+
+
+enum CLIError: Error {
+    case RestoreError(String)
+}
 
 struct VPhoneCLI: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "vphone-cli",
         abstract: "Boot a virtual iPhone or patch firmware with the Swift pipeline",
-        subcommands: [VPhoneBootCLI.self, PatchFirmwareCLI.self, PatchComponentCLI.self],
+        subcommands: [VPhoneBootCLI.self, VPhoneRestoreCLI.self, PatchFirmwareCLI.self, PatchComponentCLI.self],
         defaultSubcommand: VPhoneBootCLI.self
     )
 }
@@ -112,6 +120,232 @@ struct VPhoneBootCLI: ParsableCommand {
     }
 
     mutating func run() throws {}
+}
+
+struct VPhoneRestoreCLI: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "restore",
+        abstract: "Restore a virtual iPhone",
+    )
+
+    @Option(
+        help: "Path to VM manifest plist (config.plist). Required.",
+        transform: URL.init(fileURLWithPath:)
+    )
+    var config: URL
+    
+    @Option(
+        help: "Apple firmware variant to restore (release/research).",
+        transform: URL.init(fileURLWithPath:)
+    )
+    var ipsw: URL
+
+    @Option(help: "Apple firmware variant to restore (customer/research).")
+    var variant: FirmwareVariant = .customer
+    
+    enum FirmwareVariant: String, CaseIterable, ExpressibleByArgument {
+        case customer
+        case research
+    }
+    
+    class RestoreContextWrapper {
+        var context: RestoreContext
+        init(context: RestoreContext) {
+            self.context = context
+        }
+    }
+    
+    struct RestoreContext {
+        let config: [String: Any]
+        let completion: DispatchSemaphore
+        var status: RestoreResult = .init()
+    }
+    
+    struct RestoreResult {
+        enum State: String {
+            case notstarted, started, success, failed
+        }
+
+        var state: State = .notstarted
+        var errReason: String? = nil
+
+        mutating func setResult(state: State, errReason: String? = nil) {
+            self.state = state
+            self.errReason = errReason
+        }
+    }
+
+    // ToDo Improve: Register Log Handler
+    mutating func run() throws {
+        var config = AMRestorableDeviceCopyDefaultRestoreOptions() as! [String: Any]
+
+        config[kAMRestoreOptionsRestoreBootArgs] =
+        if let bootArgs = config[kAMRestoreOptionsRestoreBootArgs] as? String {
+            bootArgs + " serial=3"
+        } else {
+            "rd=md0 nand-enable-reformat=1 -progress -restore serial=3"
+        }
+        
+        config[kAMRestoreOptionsPostRestoreAction] = kAMRestorePostRestoreShutdown
+        config[kAMRestorableRestoreOptionWaitForDeviceConnectionToFinishStateMachine] = false
+        config[kAMRestoreOptionsPersistentBootArgModifications] = [
+            [kAMRestoreBootArgsAdd, "debug", "0x104c04"],
+            [kAMRestoreBootArgsAdd, "serial", "3"],
+        ]
+
+        config[kAMRestoreOptionsRestoreBundlePath] = ipsw.path
+        let variantName = try! restoreVariantName(variant)
+        config[kAMRestoreOptionsAuthInstallVariant] = variantName
+
+        var restoreContext = RestoreContext(
+            config: config,
+            completion: DispatchSemaphore(value: 0)
+        )
+
+        print("[vphone] restore: \(ipsw) (variant: \"\(variant.rawValue)\")")
+
+        let contextWrapper = RestoreContextWrapper(context: restoreContext)
+        let contextWrapperRaw = Unmanaged<RestoreContextWrapper>.passRetained(contextWrapper)
+        defer {
+            contextWrapperRaw.release()
+        }
+
+        var resErr: Unmanaged<CFError>?
+        let clientID = AMRestorableDeviceRegisterForNotifications(
+            newConnectionCallback,
+            contextWrapperRaw.toOpaque(),
+            &resErr
+        )
+        defer {
+            if clientID != kAMRestorableInvalidClientID {
+                AMRestorableDeviceUnregisterForNotifications(clientID)
+            }
+        }
+
+        if let resErr = resErr?.takeUnretainedValue() {
+            let errReason = CFErrorCopyDescription(resErr) as? String ?? "No Reason"
+            contextWrapper.context.status.setResult(state: .failed,
+                                                    errReason: "initialization: \(errReason)")
+            throw CLIError.RestoreError("restore init: \(errReason)")
+        }
+        defer { restoreContext = contextWrapper.context }
+
+        // 5 minutes restore timeout
+        let deadline = DispatchTime.now() + 300
+        guard contextWrapper.context.completion.wait(timeout: deadline) == .success else {
+            contextWrapper.context.status.setResult(state: .failed, errReason: "timeout")
+            throw CLIError.RestoreError("timeout")
+        }
+
+        guard contextWrapper.context.status.state == .success else {
+            throw CLIError.RestoreError("failed: \(restoreContext.status.errReason ?? "No reason")")
+        }
+    }
+}
+
+func restoreVariantName(_ variant: VPhoneRestoreCLI.FirmwareVariant) throws -> String {
+    return switch variant {
+    case VPhoneRestoreCLI.FirmwareVariant.customer: "Darwin Cloud Customer Erase Install (IPSW)"
+    case VPhoneRestoreCLI.FirmwareVariant.research: "Research Darwin Cloud Customer Erase Install (IPSW)"
+    }
+}
+
+func newConnectionCallback(
+    _ deviceRef: AMRestorableDeviceRef?,
+    _ event: AMRestorableDeviceEvent,
+    _ context: UnsafeMutableRawPointer?
+) {
+    let deviceRef = deviceRef!
+    let contextRef = Unmanaged<VPhoneRestoreCLI.RestoreContextWrapper>
+        .fromOpaque(context!)
+        .takeUnretainedValue()
+
+    guard contextRef.context.status.state == .notstarted else {
+        return
+    }
+
+    print("restore: device connected")
+    let deviceState = getAMRDeviceState(deviceRef)
+    if deviceState == kAMRestorableDeviceStateBootedOS {
+        if AMDeviceEnterRecovery(deviceRef) != 0 {
+            print("Failed to enter recovery mode")
+            return
+        }
+    }
+
+    guard [kAMRestorableDeviceStateDFU, kAMRestorableDeviceStateDFUMac].contains(deviceState) else {
+        print("Not in DFU mode")
+        let devState = getAMRDeviceState(deviceRef)
+        contextRef.context.status.setResult(state: .failed,
+                                            errReason: "VM not in DFU mode (curstate = \(devState))")
+        return
+    }
+    
+    let restoreConfig = contextRef.context.config as CFDictionary
+    contextRef.context.status.state = .started
+
+    AMRestorableDeviceRestore(
+        deviceRef,
+        restoreConfig,
+        restoreProgressCallback,
+        context
+    )
+
+    if event == kAMRestorableDeviceEventDisappeared {
+        print("Disappeared")
+        contextRef.context.status.setResult(state: .failed,
+                                            errReason: "disconnected from VM")
+    }
+}
+
+private func restoreProgressCallback(
+    _ deviceRef: AMRestorableDeviceRef?,
+    _ restoreInfo: CFDictionary?,
+    _ context: UnsafeMutableRawPointer? // &RestoreContext
+) {
+    let restoreInfo = restoreInfo! as! [String: Any]
+    let contextRef = Unmanaged<VPhoneRestoreCLI.RestoreContextWrapper>
+        .fromOpaque(context!)
+        .takeUnretainedValue()
+
+    if let progress = restoreInfo[kAMRestorableDeviceInfoKeyOverallProgress as String] {
+        if (progress as! Int32) >= 0 {
+            let printStr = String(format: "%3d", progress as! Int32)
+            print("[Restore] Progress: \(printStr)%", terminator: "\r")
+            fflush(stdout)
+        } else {
+            print("[Restore] Waiting...", terminator: "\r")
+            fflush(stdout)
+        }
+    }
+
+    let status = restoreInfo[kAMRestorableDeviceInfoKeyStatus as String]
+    guard let status = status as? String else {
+        return
+    }
+
+    if status == (kAMRestorableDeviceStatusRestoring as String) {
+        return
+    }
+
+    if status == (kAMRestorableDeviceStatusSuccessful) {
+        contextRef.context.status.setResult(state: .success)
+        print("[Restore] Completed")
+    } else {
+        var errReason = "no reason provided"
+        if let error = restoreInfo[kAMRestorableDeviceInfoKeyError] {
+            errReason = (error as! CFError).localizedDescription
+        }
+
+        contextRef.context.status.setResult(state: .failed, errReason: errReason)
+    }
+
+    contextRef.context.completion.signal()
+}
+
+private func getAMRDeviceState(_ deviceRef: AMRestorableDeviceRef) -> AMRestorableDeviceState {
+    return AMRestorableDeviceGetStateWithVersion(deviceRef,
+                                                 OpaquePointer(getAMRestorableDeviceStateVersion2()))
 }
 
 struct PatchFirmwareCLI: ParsableCommand {

--- a/sources/vphone-cli/VPhoneControl.swift
+++ b/sources/vphone-cli/VPhoneControl.swift
@@ -582,6 +582,63 @@ class VPhoneControl {
             }
         }
     }
+    
+    // MARK: - Cryptex
+    
+    struct CryptexContent {
+        let data: Data?
+    }
+    
+    func listCryptexes() async throws -> String {
+        let request: [String: Any] = ["t": "cryptex_list"]
+        let (resp, _) = try await sendRequest(request)
+        if let detail = resp["msg"] as? String, !detail.isEmpty {
+            return detail
+        }
+        return "No reponse."
+    }
+    
+    func installCryptex(localURL: URL) async throws -> String {
+        do {
+            return try await installCryptexWithBuiltInInstaller(localURL: localURL)
+        } catch let ControlError.guestError(message) where message == "unknown type: cryptex_install" {
+            throw ControlError.guestError(
+                "Guest vphoned does not support cryptex_install yet. Reconnect or reboot the guest so the updated daemon can take over."
+            )
+        }
+    }
+
+    private func installCryptexWithBuiltInInstaller(localURL: URL) async throws -> String {
+        let variant = localURL.deletingPathExtension().lastPathComponent
+        let archive = try Cryptex.createCryptex(source: localURL.path, name: variant)
+        let archiveUrl = URL(fileURLWithPath: archive)
+        
+        let data: Data
+        do {
+            data = try Data(contentsOf: archiveUrl)
+        } catch {
+            throw ControlError.protocolError("failed to read Cryptex archive: \(error)")
+        }
+
+        let remoteDir = "/var/mobile/Documents/vphone-cryptexes"
+        let remoteName = "\(UUID().uuidString)-\(localURL.lastPathComponent)"
+        let remotePath = "\(remoteDir)/\(remoteName)"
+
+        try await createDirectory(path: remoteDir)
+        try await uploadFile(path: remotePath, data: data)
+
+        let request: [String: Any] = [
+            "t": "cryptex_install",
+            "path": remotePath,
+            "variant": variant
+        ]
+        let (resp, _) = try await sendRequest(request)
+        if let detail = resp["msg"] as? String, !detail.isEmpty {
+            return detail
+        }
+        return "Installed \(localURL.lastPathComponent) Cryptex."
+    }
+
 
     // MARK: - App Management
 
@@ -894,7 +951,7 @@ class VPhoneControl {
 
     private static func timeoutForRequest(type: String) -> TimeInterval {
         switch type {
-        case "file_get", "file_put", "ipa_install":
+        case "file_get", "file_put", "ipa_install", "cryptex_install":
             transferRequestTimeout
         case "devmode", "file_list", "file_delete", "file_rename", "file_mkdir", "keychain_list",
              "app_list", "app_launch", "open_url", "accessibility_tree":

--- a/sources/vphone-cli/VPhoneCryptex.swift
+++ b/sources/vphone-cli/VPhoneCryptex.swift
@@ -1,0 +1,123 @@
+import Foundation
+import System
+
+// CryptexSpec provides a container for describing a cryptex image between various layers
+
+
+enum CryptexError: Error {
+    case FileError(String)
+    case ProcessError(String)
+    case ZipError
+}
+
+struct Cryptex: CustomStringConvertible {
+    let variant: String
+    let path: FilePath
+
+    var description: String { "\(variant):\(path.lastComponent ?? "-")" }
+
+    init(
+        path: String,
+        variant: String,
+    ) throws {
+        guard FileManager.default.fileExists(atPath: path) else {
+            throw POSIXError(.ENOENT)
+        }
+        guard FileManager.default.isReadableFile(atPath: path) else {
+            throw POSIXError(.EFTYPE)
+        }
+
+        self.path = FilePath(path)
+        self.variant = variant
+    }
+    
+    static func createCryptex(source: String, name: String) throws -> String {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appending(path: "vphone-\(UUID.init().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+        
+        let diskImagePath = try createDiskImage(sourceDirectory: source, tmpDir: tmpDir)
+        let cryptexPath = try createCryptex(imagePath: diskImagePath, name: name, tmpDir: tmpDir)
+        let cryptexArchivePath = try createCryptexArchive(cryptexPath: cryptexPath, name: name)
+        return cryptexArchivePath
+    }
+    
+    static func createDiskImage(sourceDirectory: String, tmpDir: URL) throws -> String {
+        let diskImageURL = tmpDir.appendingPathComponent("cryptex.dmg")
+        _ = try runProcess("/usr/bin/hdiutil", ["create", "-srcfolder", sourceDirectory, diskImageURL.path])
+        return diskImageURL.path
+    }
+
+    static func createCryptex(imagePath: String, name: String, tmpDir: URL) throws -> String {
+        _ = try runProcess("/System/Library/SecurityResearch/usr/bin/cryptexctl.research", [
+            "create",
+            "--output-directory=\(tmpDir.path)",
+            "--restricted-exec-mode-default=both",
+            "--identifier=\(name)",
+            "--mount-point=/private/var/PrivateCloudSupportInternalAdditions", // We currently support only one cryptex
+            "-v", "1",
+            "-V", name,
+            "--FCHP=0xff10",
+            "--TYPE=0x3",
+            "--STYP=0x1",
+            "--CLAS=0xf2",
+            "--NDOM=0x3",
+            "--BORD=0x90",
+            "--CHIP=0xfe01",
+            "--SDOM=0x1",
+            imagePath,
+        ])
+
+        let newCryptexURL = tmpDir.appending(component: "\(name).cxbd")
+        return newCryptexURL.path
+    }
+
+    static func createCryptexArchive(cryptexPath: String, name: String) throws -> String {
+        let tmpDir = FileManager.default.temporaryDirectory.appending(path: "vphone-\(UUID.init().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        let archivePath = tmpDir.appending(path: name + ".tar")
+        
+        let cryptexUrl = URL(fileURLWithPath: cryptexPath)
+
+        _ = try runProcess("/usr/bin/tar", [
+            "-c",
+            "-C", cryptexUrl.deletingLastPathComponent().path,
+            "-f", archivePath.path,
+            cryptexUrl.lastPathComponent])
+
+        return archivePath.path
+    }
+    
+    static func runProcess(_ launchPath: String, _ arguments: [String], sudo: Bool = false, output: URL? = nil) throws -> String {
+        let process = Process()
+        if sudo {
+            let whoami = try runProcess("/usr/bin/whoami", [])
+            if !whoami.contains("root") {
+                print("Please rerun as root or fix this program")
+                exit(42)
+            }
+        }
+        process.executableURL = URL(fileURLWithPath: launchPath)
+        process.arguments = arguments
+
+        let outPipe = Pipe()
+        if let output {
+            let outFile = try FileHandle.init(forWritingTo: output)
+            process.standardOutput = outFile
+            process.standardError = outFile
+        } else {
+            process.standardOutput = outPipe
+            process.standardError = outPipe
+        }
+
+        try process.run()
+        process.waitUntilExit()
+
+        let output = output == nil ? String(data: outPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) : nil
+        guard process.terminationStatus == 0 else {
+            throw CryptexError.ProcessError("\(process.terminationStatus), \(output ?? "")")
+        }
+        return output ?? ""
+    }
+}

--- a/sources/vphone-cli/VPhoneMenuApps.swift
+++ b/sources/vphone-cli/VPhoneMenuApps.swift
@@ -27,6 +27,18 @@ extension VPhoneMenuController {
         install.isEnabled = false
         installPackageItem = install
         menu.addItem(install)
+        
+        menu.addItem(NSMenuItem.separator())
+
+        let listCryptex = makeItem("List Cryptexes", action: #selector(listCryptexes))
+        listCryptex.isEnabled = false
+        listCryptexesItem = listCryptex
+        menu.addItem(listCryptex)
+
+        let cryptex = makeItem("Install Cryptex...", action: #selector(installCryptexFromDisk))
+        cryptex.isEnabled = false
+        installCryptexItem = cryptex
+        menu.addItem(cryptex)
 
         item.submenu = menu
         return item
@@ -42,6 +54,11 @@ extension VPhoneMenuController {
 
     func updateInstallAvailability(available: Bool) {
         installPackageItem?.isEnabled = available
+    }
+    
+    func updateCryptexAvailability(available: Bool) {
+        installCryptexItem?.isEnabled = available
+        listCryptexesItem?.isEnabled = available
     }
 
     @objc func openAppBrowser() {
@@ -79,6 +96,64 @@ extension VPhoneMenuController {
                 )
             } catch {
                 showAlert(title: "Install App Package", message: "\(error)", style: .warning)
+            }
+        }
+    }
+    
+    @objc func installCryptexFromDisk() {
+        guard control.isConnected else {
+            showAlert(title: "Install Cryptex", message: "Guest is not connected.", style: .warning)
+            return
+        }
+
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.prompt = "Install"
+        panel.message = "Choose the built Cryptex source directory."
+
+        let response = panel.runModal()
+        guard response == .OK, let url = panel.url else { return }
+
+        Task {
+            do {
+                let result = try await control.installCryptex(localURL: url)
+                print("[install] \(result)")
+                showAlert(
+                    title: "Install Cryptex",
+                    message: VPhoneInstallPackage.successMessage(
+                        for: url.lastPathComponent,
+                        detail: result
+                    ),
+                    style: .informational
+                )
+            } catch {
+                showAlert(title: "Install Cryptex", message: "\(error)", style: .warning)
+            }
+        }
+    }
+    
+    @objc func listCryptexes() {
+        guard control.isConnected else {
+            showAlert(title: "List Cryptexes", message: "Guest is not connected.", style: .warning)
+            return
+        }
+
+        Task {
+            do {
+                let result = try await control.listCryptexes()
+                print("[list] \(result)")
+                showAlert(
+                    title: "List Cryptexes",
+                    message: VPhoneInstallPackage.successMessage(
+                        for: "",
+                        detail: result
+                    ),
+                    style: .informational
+                )
+            } catch {
+                showAlert(title: "List Cryptexes", message: "\(error)", style: .warning)
             }
         }
     }

--- a/sources/vphone-cli/VPhoneMenuController.swift
+++ b/sources/vphone-cli/VPhoneMenuController.swift
@@ -18,6 +18,8 @@ class VPhoneMenuController {
     var connectPingItem: NSMenuItem?
     var connectGuestVersionItem: NSMenuItem?
     var installPackageItem: NSMenuItem?
+    var installCryptexItem: NSMenuItem?
+    var listCryptexesItem: NSMenuItem?
     var clipboardGetItem: NSMenuItem?
     var clipboardSetItem: NSMenuItem?
     var appsListItem: NSMenuItem?

--- a/sources/vphone-cli/main.swift
+++ b/sources/vphone-cli/main.swift
@@ -12,14 +12,9 @@ do {
         app.delegate = delegate
         app.run()
 
-    case var patch as PatchFirmwareCLI:
-        try patch.run()
-
-    case var patch as PatchComponentCLI:
-        try patch.run()
-
     default:
-        break
+        var command = command
+        try command.run()
     }
 } catch {
     VPhoneCLI.exit(withError: error)


### PR DESCRIPTION
This PR adds functionality to install and list Cryptexes via `vphoned`.

Cryptexes are overlay file systems that can contain data, executables, and daemons, which can be added at runtime within the boundaries of Apple's security ecosystem.
Cryptexes are also being used in the context of Apple's physical Security Research Devices. Therefore, this feature allows security researchers to easily use their Cryptex toolchains also for researching with the vphone.

While developing the cryptex support for the vphone, we hit a limitation of pymobiledevice3. We opened https://github.com/doronz88/pymobiledevice3/issues/1701 and hope to remove f05a53a924ad6424dc5cf9ad9773761ef1f6d625 once this is resolved. Meanwhile, we perform the restore with Apple's MobileDevice library (f05a53a924ad6424dc5cf9ad9773761ef1f6d625). We have limited this to the patchless mode, for now.

In this PR, we use and copy the `cryptexctl` executable from the cloudOS filesystem as a utility. A future PR, however, might use the (private Swift) `CryptexKit` framework directly from `vphoned`.
