### PR TITLE
APFS CoW snapshots: instant backups with no extra disk space

### DIFF
--- a/scripts/vm_backup.sh
+++ b/scripts/vm_backup.sh
@@ -1,13 +1,18 @@
 #!/bin/zsh
 # vm_backup.sh — Save the current VM as a named backup.
 #
-# Backups are stored under vm.backups/<name>/ using rsync --sparse.
+# Backups are stored under vm.backups/<name>/.
 # The active VM remembers its name in vm/.vm_name for use by vm_switch.
 #
 # Usage:
 #   make vm_backup NAME=ios17
 #   make vm_backup NAME=ios18-jb BACKUP_INCLUDE_IPSW=1
 set -euo pipefail
+
+# Try cp -c for APFS clone/COW first; fall back to cp -a where -c is unsupported.
+_vphone_cp() {
+    cp -a -c "$@" 2>/dev/null || cp -a "$@"
+}
 
 VM_DIR="${VM_DIR:-vm}"
 BACKUPS_DIR="${BACKUPS_DIR:-vm.backups}"
@@ -68,19 +73,31 @@ echo "Dest   : ${DEST}/"
 src_size="$(du -sh "${VM_DIR}" 2>/dev/null | cut -f1)"
 echo "Size   : ${src_size} (on disk)"
 
-RSYNC_EXCLUDES=()
 if [[ "${BACKUP_INCLUDE_IPSW}" != "1" ]]; then
-    RSYNC_EXCLUDES+=(--exclude '*_Restore*/')
     echo "IPSW   : excluded (use BACKUP_INCLUDE_IPSW=1 to include)"
+else
+    echo "IPSW   : included"
 fi
 echo ""
 
 # --- Sync ---
 mkdir -p "${DEST}"
 
-rsync -aH --sparse --progress --delete \
-    "${RSYNC_EXCLUDES[@]}" \
-    "${VM_DIR}/" "${DEST}/"
+# Use cp for speed.
+# On APFS, cp -c can create an instant copy-on-write clone.
+# If -c is unsupported, _vphone_cp falls back to cp -a.
+while IFS= read -r -d '' item; do
+    base="$(basename "${item}")"
+
+    # Skip IPSW restore dirs if excluded.
+    if [[ "${BACKUP_INCLUDE_IPSW}" != "1" && "${base}" == *_Restore* ]]; then
+        continue
+    fi
+
+    if [[ -d "${item}" || -f "${item}" ]]; then
+        _vphone_cp "${item}" "${DEST}/"
+    fi
+done < <(find "${VM_DIR}" -mindepth 1 -maxdepth 1 -print0)
 
 # Tag the active VM with this name
 echo "${NAME}" > "${VM_DIR}/.vm_name"

--- a/scripts/vm_restore.sh
+++ b/scripts/vm_restore.sh
@@ -4,7 +4,13 @@
 # Usage:
 #   make vm_restore NAME=ios17
 #   make vm_restore NAME=ios17 FORCE=1
+
 set -euo pipefail
+
+# Try cp -c for APFS clone/COW first; fall back to cp -a where -c is unsupported.
+_vphone_cp() {
+    cp -a -c "$@" 2>/dev/null || cp -a "$@"
+}
 
 VM_DIR="${VM_DIR:-vm}"
 BACKUPS_DIR="${BACKUPS_DIR:-vm.backups}"
@@ -14,10 +20,48 @@ FORCE="${FORCE:-0}"
 validate_backup_name() {
     local name="$1"
     local label="${2:-NAME}"
+
+    if [[ -z "${name}" ]]; then
+        echo "ERROR: ${label} is required."
+        exit 1
+    fi
+
     if [[ "$name" == */* || "$name" == .* ]]; then
         echo "ERROR: ${label} must be a simple identifier (no slashes or leading dots)."
         exit 1
     fi
+}
+
+list_backups() {
+    if [[ ! -d "${BACKUPS_DIR}" ]]; then
+        echo "  (none)"
+        return
+    fi
+
+    local found=0
+
+    while IFS= read -r -d '' d; do
+        if [[ -f "${d}/config.plist" ]]; then
+            echo "  - $(basename "${d}")"
+            found=1
+        fi
+    done < <(find "${BACKUPS_DIR}" -mindepth 1 -maxdepth 1 -type d -print0)
+
+    if [[ "${found}" != "1" ]]; then
+        echo "  (none)"
+    fi
+}
+
+safe_clear_vm_dir() {
+    if [[ -z "${VM_DIR}" || "${VM_DIR}" == "/" || "${VM_DIR}" == "." ]]; then
+        echo "ERROR: Refusing to clear unsafe VM_DIR: '${VM_DIR}'"
+        exit 1
+    fi
+
+    mkdir -p "${VM_DIR}"
+
+    # Delete all direct contents, including hidden files.
+    find "${VM_DIR}" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
 }
 
 # --- Parse args ---
@@ -38,13 +82,7 @@ if [[ -z "${NAME}" ]]; then
     echo "  Usage: make vm_restore NAME=ios17"
     echo ""
     echo "Available backups:"
-    if [[ -d "${BACKUPS_DIR}" ]]; then
-        for d in "${BACKUPS_DIR}"/*/; do
-            [[ -f "${d}config.plist" ]] && echo "  - $(basename "${d}")"
-        done
-    else
-        echo "  (none)"
-    fi
+    list_backups
     exit 1
 fi
 
@@ -57,13 +95,7 @@ if [[ ! -d "${SRC}" ]]; then
     echo "ERROR: Backup '${NAME}' not found at ${SRC}/"
     echo ""
     echo "Available backups:"
-    if [[ -d "${BACKUPS_DIR}" ]]; then
-        for d in "${BACKUPS_DIR}"/*/; do
-            [[ -f "${d}config.plist" ]] && echo "  - $(basename "${d}")"
-        done
-    else
-        echo "  (none)"
-    fi
+    list_backups
     exit 1
 fi
 
@@ -80,11 +112,12 @@ if pgrep -f "vphone-cli.*--config.*${VM_DIR}" >/dev/null 2>&1; then
 fi
 
 # --- Confirm overwrite ---
-if [[ -d "${VM_DIR}" && -f "${VM_DIR}/Disk.img" && "${FORCE}" != "1" ]]; then
+if [[ -d "${VM_DIR}" && "${FORCE}" != "1" ]]; then
     current=""
     [[ -f "${VM_DIR}/.vm_name" ]] && current="$(< "${VM_DIR}/.vm_name")"
     echo "WARNING: ${VM_DIR}/ already exists${current:+ (current: '${current}')}."
-    echo "  This will overwrite it with backup '${NAME}'."
+    echo "  This will replace it with backup '${NAME}'."
+    echo "  Existing files in ${VM_DIR}/ will be deleted first."
     echo "  Back up first with: make vm_backup NAME=<name>"
     printf "Continue? [y/N] "
     read -r answer
@@ -99,13 +132,16 @@ backup_size="$(du -sh "${SRC}" 2>/dev/null | cut -f1)"
 echo "Size   : ${backup_size} (on disk)"
 echo ""
 
-# --- Sync ---
-mkdir -p "${VM_DIR}"
+# --- Restore ---
+safe_clear_vm_dir
 
-rsync -aH --sparse --progress --delete \
-    "${SRC}/" "${VM_DIR}/"
+while IFS= read -r -d '' item; do
+    if [[ -d "${item}" || -f "${item}" ]]; then
+        _vphone_cp "${item}" "${VM_DIR}/"
+    fi
+done < <(find "${SRC}" -mindepth 1 -maxdepth 1 -print0)
 
-# Tag the active VM
+# Tag the active VM.
 echo "${NAME}" > "${VM_DIR}/.vm_name"
 
 echo ""

--- a/scripts/vm_switch.sh
+++ b/scripts/vm_switch.sh
@@ -6,7 +6,14 @@
 #
 # Usage:
 #   make vm_switch NAME=ios18
+#   make vm_switch NAME=ios18 BACKUP_INCLUDE_IPSW=1
+
 set -euo pipefail
+
+# Try cp -c for APFS clone/COW first; fall back to cp -a where -c is unsupported.
+_vphone_cp() {
+    cp -a -c "$@" 2>/dev/null || cp -a "$@"
+}
 
 VM_DIR="${VM_DIR:-vm}"
 BACKUPS_DIR="${BACKUPS_DIR:-vm.backups}"
@@ -16,10 +23,86 @@ BACKUP_INCLUDE_IPSW="${BACKUP_INCLUDE_IPSW:-0}"
 validate_backup_name() {
     local name="$1"
     local label="${2:-NAME}"
-    if [[ "$name" == */* || "$name" == .* ]]; then
+
+    if [[ -z "${name}" ]]; then
+        echo "ERROR: ${label} is required."
+        exit 1
+    fi
+
+    if [[ "${name}" == */* || "${name}" == .* ]]; then
         echo "ERROR: ${label} must be a simple identifier (no slashes or leading dots)."
         exit 1
     fi
+}
+
+validate_safe_path() {
+    local path="$1"
+    local label="$2"
+
+    if [[ -z "${path}" || "${path}" == "/" || "${path}" == "." || "${path}" == ".." ]]; then
+        echo "ERROR: Refusing unsafe ${label}: '${path}'"
+        exit 1
+    fi
+}
+
+list_backups() {
+    if [[ ! -d "${BACKUPS_DIR}" ]]; then
+        echo "  (none)"
+        return
+    fi
+
+    local found=0
+
+    while IFS= read -r -d '' d; do
+        if [[ -f "${d}/config.plist" ]]; then
+            echo "  - $(basename "${d}")"
+            found=1
+        fi
+    done < <(find "${BACKUPS_DIR}" -mindepth 1 -maxdepth 1 -type d -print0)
+
+    if [[ "${found}" != "1" ]]; then
+        echo "  (none)"
+    fi
+}
+
+copy_children() {
+    local src="$1"
+    local dst="$2"
+    local include_ipsw="${3:-1}"
+
+    mkdir -p "${dst}"
+
+    while IFS= read -r -d '' item; do
+        base="$(basename "${item}")"
+
+        if [[ "${include_ipsw}" != "1" && "${base}" == *_Restore* ]]; then
+            continue
+        fi
+
+        _vphone_cp "${item}" "${dst}/"
+    done < <(find "${src}" -mindepth 1 -maxdepth 1 \( -type f -o -type d -o -type l \) -print0)
+}
+
+replace_dir_with_tmp() {
+    local tmp="$1"
+    local dest="$2"
+    local old="${dest}.old.$$"
+
+    rm -rf -- "${old}"
+
+    if [[ -e "${dest}" || -L "${dest}" ]]; then
+        mv -- "${dest}" "${old}"
+    fi
+
+    if ! mv -- "${tmp}" "${dest}"; then
+        if [[ -e "${old}" || -L "${old}" ]]; then
+            mv -- "${old}" "${dest}"
+        fi
+        echo "ERROR: Failed to replace ${dest}"
+        exit 1
+    fi
+
+    rm -rf -- "${old}"
 }
 
 # --- Parse args ---
@@ -40,17 +123,13 @@ if [[ -z "${NAME}" ]]; then
     echo "  Usage: make vm_switch NAME=ios18"
     echo ""
     echo "Available backups:"
-    if [[ -d "${BACKUPS_DIR}" ]]; then
-        for d in "${BACKUPS_DIR}"/*/; do
-            [[ -f "${d}config.plist" ]] && echo "  - $(basename "${d}")"
-        done
-    else
-        echo "  (none)"
-    fi
+    list_backups
     exit 1
 fi
 
 validate_backup_name "${NAME}"
+validate_safe_path "${VM_DIR}" "VM_DIR"
+validate_safe_path "${BACKUPS_DIR}" "BACKUPS_DIR"
 
 TARGET="${BACKUPS_DIR}/${NAME}"
 
@@ -58,13 +137,7 @@ if [[ ! -d "${TARGET}" || ! -f "${TARGET}/config.plist" ]]; then
     echo "ERROR: Backup '${NAME}' not found."
     echo ""
     echo "Available backups:"
-    if [[ -d "${BACKUPS_DIR}" ]]; then
-        for d in "${BACKUPS_DIR}"/*/; do
-            [[ -f "${d}config.plist" ]] && echo "  - $(basename "${d}")"
-        done
-    else
-        echo "  (none)"
-    fi
+    list_backups
     exit 1
 fi
 
@@ -74,6 +147,8 @@ if pgrep -f "vphone-cli.*--config.*${VM_DIR}" >/dev/null 2>&1; then
     echo "  Stop the VM before switching."
     exit 1
 fi
+
+mkdir -p "${BACKUPS_DIR}"
 
 # --- Determine current VM name ---
 CURRENT=""
@@ -85,7 +160,8 @@ if [[ -d "${VM_DIR}" && -f "${VM_DIR}/config.plist" ]]; then
     if [[ -z "${CURRENT}" ]]; then
         echo "Current VM has no name. Give it one to save before switching."
         printf "Name for current VM: "
-        read -r CURRENT
+        read -r CURRENT || CURRENT=""
+
         if [[ -z "${CURRENT}" ]]; then
             echo "ERROR: Cannot switch without saving the current VM."
             exit 1
@@ -99,19 +175,18 @@ if [[ -d "${VM_DIR}" && -f "${VM_DIR}/config.plist" ]]; then
         exit 0
     fi
 
-    # --- Save current ---
     echo "=== Saving current VM as '${CURRENT}' ==="
+
     CURRENT_DEST="${BACKUPS_DIR}/${CURRENT}"
-    mkdir -p "${CURRENT_DEST}"
+    TMP_CURRENT_DEST="${BACKUPS_DIR}/.${CURRENT}.tmp.$$"
 
-    RSYNC_EXCLUDES=()
-    if [[ "${BACKUP_INCLUDE_IPSW}" != "1" ]]; then
-        RSYNC_EXCLUDES+=(--exclude '*_Restore*/')
-    fi
+    rm -rf -- "${TMP_CURRENT_DEST}"
+    mkdir -p "${TMP_CURRENT_DEST}"
 
-    rsync -aH --sparse --progress --delete \
-        "${RSYNC_EXCLUDES[@]}" \
-        "${VM_DIR}/" "${CURRENT_DEST}/"
+    copy_children "${VM_DIR}" "${TMP_CURRENT_DEST}" "${BACKUP_INCLUDE_IPSW}"
+    echo "${CURRENT}" > "${TMP_CURRENT_DEST}/.vm_name"
+
+    replace_dir_with_tmp "${TMP_CURRENT_DEST}" "${CURRENT_DEST}"
 
     echo ""
 fi
@@ -119,12 +194,15 @@ fi
 # --- Restore target ---
 echo "=== Restoring '${NAME}' ==="
 
-mkdir -p "${VM_DIR}"
+TMP_VM_DIR="${VM_DIR}.restore.$$"
 
-rsync -aH --sparse --progress --delete \
-    "${TARGET}/" "${VM_DIR}/"
+rm -rf -- "${TMP_VM_DIR}"
+mkdir -p "${TMP_VM_DIR}"
 
-echo "${NAME}" > "${VM_DIR}/.vm_name"
+copy_children "${TARGET}" "${TMP_VM_DIR}" "1"
+echo "${NAME}" > "${TMP_VM_DIR}/.vm_name"
+
+replace_dir_with_tmp "${TMP_VM_DIR}" "${VM_DIR}"
 
 echo ""
 echo "=== Switched: ${CURRENT:+${CURRENT} → }${NAME} ==="


### PR DESCRIPTION
Simply utilizing the fact that APFS has CoW to make vm backups instant and save storage.


# APFS CoW Snapshot Benchmark


`make vm_backup` on `main` (rsync) vs `fast-snapshot-clone` (cp -a -c).

## Test Environment

| Component | Details |
|-----------|---------|
| **Host** |  MacBook Pro (Mac17,2), Apple M5 (10-core) |
| **OS** | macOS 26.5.1 (25F80), Darwin 25.5.0, APFS internal SSD |
| **VM** | iPhone17,3 (iPhone 99,11), iOS 26.1 (23B85), 64 GiB sparse Disk.img |
| **Disk.img** | 64 GiB logical, ~17 GiB allocated |

All tests on the same machine, VM stopped, same vm/ directory.



## 1. `main` branch — `rsync -aH --sparse`

```bash
git checkout main
/usr/bin/time -l make vm_backup NAME=rsync_test
```

```
real    4m13.2s
user    2m12.0s
sys     1m47.2s
```

## 2. `fast-snapshot-clone` branch — `cp -a -c`

```bash
git checkout fast-snapshot-clone
/usr/bin/time -l make vm_backup NAME=cow_test
```

```
real    0m0.086s
user    0m0.028s
sys     0m0.035s
```

---

## Storage Cost: `df` Before/After

Same guard used for both tests — only on the same APFS volume:

```bash
src_dev=$(df -k vm | awk 'NR==2 {print $1}')
dst_dev=$(df -k vm.backups | awk 'NR==2 {print $1}')
test "$src_dev" = "$dst_dev" || exit 1
sync
before=$(df -k vm | awk 'NR==2 {print $4}')
make vm_backup NAME=bench
sync
after=$(df -k vm | awk 'NR==2 {print $4}')
echo "Delta: $((before - after)) KiB"
```

### `fast-snapshot-clone` (cp -a -c)

```
Before: 778551040 KiB free
Delta:  32 KiB
```

32 KiB overhead for cloning all 18 items in `vm/`. APFS metadata and directory entries. Disk.img (17 GiB apparent) cost 0 KiB — shared extents.

### `main` (rsync)

```
Before: 778550840 KiB free
Delta:  24,079,424 KiB
```

24,079,424 KiB ≈ **22.96 GiB** — a full separate copy of every allocated block in Disk.img plus all other files.


## Summary

| Aspect | rsync | cp -a -c CoW |
|--------|-------|--------------|
| **Time** | 4 min 13 s | 86 ms |
| **Extra storage** | ~23 GiB | 32 KiB |
