### PR TITLE
Fix chained firmware patch data flow

### DIFF
--- a/sources/FirmwarePatcher/IBoot/IBootPatcher.swift
+++ b/sources/FirmwarePatcher/IBoot/IBootPatcher.swift
@@ -202,8 +202,13 @@ public class IBootPatcher: Patcher {
         }
         guard let labelBytes = labelStr.data(using: .ascii) else { return }
 
-        // Collect all runs of '=' (>=20 chars) — same logic as Python.
         let raw = buffer.original
+        if raw.range(of: labelBytes) != nil {
+            if verbose { print("  [*] serial labels: already present, skipping") }
+            return
+        }
+
+        // Collect all runs of '=' (>=20 chars) — same logic as Python.
         var eqRuns: [Int] = []
         var i = raw.startIndex
 

--- a/sources/FirmwarePatcher/IBoot/IBootPatcher.swift
+++ b/sources/FirmwarePatcher/IBoot/IBootPatcher.swift
@@ -202,13 +202,8 @@ public class IBootPatcher: Patcher {
         }
         guard let labelBytes = labelStr.data(using: .ascii) else { return }
 
-        let raw = buffer.original
-        if raw.range(of: labelBytes) != nil {
-            if verbose { print("  [*] serial labels: already present, skipping") }
-            return
-        }
-
         // Collect all runs of '=' (>=20 chars) — same logic as Python.
+        let raw = buffer.original
         var eqRuns: [Int] = []
         var i = raw.startIndex
 
@@ -228,6 +223,16 @@ public class IBootPatcher: Patcher {
         }
 
         if eqRuns.count < 2 {
+            var labelCount = 0
+            var searchStart = raw.startIndex
+            while let range = raw.range(of: labelBytes, in: searchStart ..< raw.endIndex) {
+                labelCount += 1
+                searchStart = range.upperBound
+            }
+            if labelCount >= 2 {
+                if verbose { print("  [*] serial labels: already present, skipping") }
+                return
+            }
             if verbose { print("  [-] serial labels: <2 banner runs found") }
             return
         }

--- a/sources/FirmwarePatcher/Pipeline/FirmwarePipeline.swift
+++ b/sources/FirmwarePatcher/Pipeline/FirmwarePipeline.swift
@@ -134,7 +134,7 @@ public final class FirmwarePipeline {
             var componentRecords: [PatchRecord] = []
 
             for makePatcher in component.patcherFactories {
-                let patcher = makePatcher(rawData, verbose)
+                let patcher = makePatcher(currentData, verbose)
                 let records = try patcher.findAll()
 
                 guard !records.isEmpty else {
@@ -145,18 +145,7 @@ public final class FirmwarePipeline {
                 log("  [+] \(count) \(component.name) patches applied")
 
                 componentRecords.append(contentsOf: records)
-                if let deviceTreePatcher = patcher as? DeviceTreePatcher {
-                    currentData = deviceTreePatcher.patchedData
-                } else if let filesystemPatcher = patcher as? CryptexFilesystemPatcher {
-                    currentData = filesystemPatcher.patchedData
-                } else if let manifestPatcher = patcher as? ManifestHashPatcher {
-                    currentData = manifestPatcher.patchedData
-                } else {
-                    for record in records {
-                        let range = record.fileOffset ..< record.fileOffset + record.patchedBytes.count
-                        currentData.replaceSubrange(range, with: record.patchedBytes)
-                    }
-                }
+                currentData = extractPatchedData(from: patcher, fallback: currentData, records: records)
             }
 
             try loader.save(currentData, to: fileURL)

--- a/sources/FirmwarePatcher/Pipeline/FirmwarePipeline.swift
+++ b/sources/FirmwarePatcher/Pipeline/FirmwarePipeline.swift
@@ -129,24 +129,11 @@ public final class FirmwarePipeline {
             let rawData = try loader.load(from: fileURL)
             log("  format: \(rawData.count) bytes")
 
-            // Patch
-            var currentData = rawData
-            var componentRecords: [PatchRecord] = []
-
-            for makePatcher in component.patcherFactories {
-                let patcher = makePatcher(currentData, verbose)
-                let records = try patcher.findAll()
-
-                guard !records.isEmpty else {
-                    throw PatcherError.patchSiteNotFound("\(component.name): no patches found")
-                }
-
-                let count = try patcher.apply()
-                log("  [+] \(count) \(component.name) patches applied")
-
-                componentRecords.append(contentsOf: records)
-                currentData = extractPatchedData(from: patcher, fallback: currentData, records: records)
-            }
+            let (currentData, componentRecords) = try patchData(
+                rawData,
+                componentName: component.name,
+                patcherFactories: component.patcherFactories
+            )
 
             try loader.save(currentData, to: fileURL)
             log("  [+] saved")
@@ -159,6 +146,32 @@ public final class FirmwarePipeline {
         log(String(repeating: "=", count: 60))
 
         return allRecords
+    }
+
+    func patchData(
+        _ rawData: Data,
+        componentName: String,
+        patcherFactories: [(Data, Bool) -> any Patcher]
+    ) throws -> (Data, [PatchRecord]) {
+        var currentData = rawData
+        var componentRecords: [PatchRecord] = []
+
+        for makePatcher in patcherFactories {
+            let patcher = makePatcher(currentData, verbose)
+            let records = try patcher.findAll()
+
+            guard !records.isEmpty else {
+                throw PatcherError.patchSiteNotFound("\(componentName): no patches found")
+            }
+
+            let count = try patcher.apply()
+            log("  [+] \(count) \(componentName) patches applied")
+
+            componentRecords.append(contentsOf: records)
+            currentData = extractPatchedData(from: patcher, fallback: currentData, records: records)
+        }
+
+        return (currentData, componentRecords)
     }
 
     // MARK: - Component List Builder

--- a/tests/FirmwarePatcherTests/FirmwarePatcherTests.swift
+++ b/tests/FirmwarePatcherTests/FirmwarePatcherTests.swift
@@ -298,6 +298,31 @@ struct BinaryBufferTests {
     }
 }
 
+struct IBootPatcherIdempotencyTests {
+    @Test func serialLabelsPatchTwoBannerRunsWhenLabelAbsent() {
+        let banner = String(repeating: "=", count: 32)
+        let payload = Data("prefix \(banner) middle \(banner) suffix".utf8)
+        let patcher = IBootPatcher(data: payload, mode: .ibss, verbose: false)
+
+        patcher.patchSerialLabels()
+
+        #expect(patcher.patches.count == 2)
+        #expect(patcher.patches.allSatisfy {
+            String(data: $0.patchedBytes, encoding: .ascii) == "Loaded iBSS"
+        })
+    }
+
+    @Test func serialLabelsSkipWhenLabelAlreadyPresent() {
+        let banner = String(repeating: "=", count: 32)
+        let payload = Data("Loaded iBSS\0 prefix \(banner) middle \(banner) suffix".utf8)
+        let patcher = IBootPatcher(data: payload, mode: .ibss, verbose: false)
+
+        patcher.patchSerialLabels()
+
+        #expect(patcher.patches.isEmpty)
+    }
+}
+
 struct IM4PPayloadParityTests {
     @Test func ibssIM4PPayloadMatchesRawAndJBPatcherFindsNoncePatch() throws {
         let baseDir = URL(fileURLWithPath: #filePath)

--- a/tests/FirmwarePatcherTests/FirmwarePatcherTests.swift
+++ b/tests/FirmwarePatcherTests/FirmwarePatcherTests.swift
@@ -298,6 +298,65 @@ struct BinaryBufferTests {
     }
 }
 
+final class BytePatchPatcher: Patcher {
+    let component = "test"
+    let verbose = false
+    let data: Data
+    let offset: Int
+    let byte: UInt8
+    let id: String
+
+    init(data: Data, offset: Int, byte: UInt8, id: String) {
+        self.data = data
+        self.offset = offset
+        self.byte = byte
+        self.id = id
+    }
+
+    func findAll() throws -> [PatchRecord] {
+        [
+            PatchRecord(
+                patchID: id,
+                component: component,
+                fileOffset: offset,
+                originalBytes: Data([data[offset]]),
+                patchedBytes: Data([byte]),
+                description: id
+            ),
+        ]
+    }
+
+    func apply() throws -> Int { 1 }
+}
+
+struct FirmwarePipelineDataFlowTests {
+    @Test func chainedPatchersReceivePreviousPatchedBytes() throws {
+        let pipeline = FirmwarePipeline(
+            vmDirectory: URL(fileURLWithPath: NSTemporaryDirectory()),
+            verbose: false
+        )
+        var secondInput = Data()
+
+        let (patched, records) = try pipeline.patchData(
+            Data([0x00, 0x00]),
+            componentName: "test",
+            patcherFactories: [
+                { data, _ in
+                    BytePatchPatcher(data: data, offset: 0, byte: 0xAA, id: "first")
+                },
+                { data, _ in
+                    secondInput = data
+                    return BytePatchPatcher(data: data, offset: 1, byte: 0xBB, id: "second")
+                },
+            ]
+        )
+
+        #expect(secondInput == Data([0xAA, 0x00]))
+        #expect(patched == Data([0xAA, 0xBB]))
+        #expect(records.map(\.patchID) == ["first", "second"])
+    }
+}
+
 struct IBootPatcherIdempotencyTests {
     @Test func serialLabelsPatchTwoBannerRunsWhenLabelAbsent() {
         let banner = String(repeating: "=", count: 32)
@@ -313,13 +372,22 @@ struct IBootPatcherIdempotencyTests {
     }
 
     @Test func serialLabelsSkipWhenLabelAlreadyPresent() {
+        let payload = Data("Loaded iBSS\0 middle Loaded iBSS\0 suffix".utf8)
+        let patcher = IBootPatcher(data: payload, mode: .ibss, verbose: false)
+
+        patcher.patchSerialLabels()
+
+        #expect(patcher.patches.isEmpty)
+    }
+
+    @Test func serialLabelsDoNotSkipForUnrelatedSingleLabel() {
         let banner = String(repeating: "=", count: 32)
         let payload = Data("Loaded iBSS\0 prefix \(banner) middle \(banner) suffix".utf8)
         let patcher = IBootPatcher(data: payload, mode: .ibss, verbose: false)
 
         patcher.patchSerialLabels()
 
-        #expect(patcher.patches.isEmpty)
+        #expect(patcher.patches.count == 2)
     }
 }
 


### PR DESCRIPTION
## Summary

Fix `FirmwarePipeline` so chained patchers for the same component are constructed from the bytes produced by the previous patcher, not from the original component bytes.

Also tighten iBoot serial-label idempotency so an unrelated single `Loaded iBSS` / `Loaded iBEC` label does not suppress patching real banner runs.

## Reproduction

1. Start from a prepared VM tree with JB or EXP patching enabled.
2. Run a variant that chains multiple patchers for one component, for example `make fw_patch_jb` or `make fw_patch_exp`.
3. Inspect a chained component such as iBSS or kernelcache.

Before this change, later patchers were initialized from stale `rawData`, even though `currentData` had been updated after each patcher. Re-running iBoot serial-label patching could also skip or fail incorrectly depending on whether a label string appeared in the payload.

## Before

- `FirmwarePipeline.patchAll()` maintained `currentData`, but each `patcherFactory` still received the original `rawData`.
- iBoot serial-label idempotency skipped when the label bytes appeared anywhere in the payload.

## After

- Each patcher receives the latest `currentData`.
- The pipeline updates `currentData` through the existing patched-data extraction path after each patcher applies.
- iBoot serial-label idempotency only treats the component as already patched when the expected label count is present.

## Verification

```sh
swift test --filter FirmwarePipelineDataFlowTests
swift test --filter IBootPatcherIdempotencyTests
```

Key output:

```text
Suite FirmwarePipelineDataFlowTests passed
Test run with 1 test in 1 suite passed

Suite IBootPatcherIdempotencyTests passed
Test run with 3 tests in 1 suite passed
```
