### PR TITLE
Patch active TXM for normal JB boot

### DIFF
--- a/research/0_binary_patch_comparison.md
+++ b/research/0_binary_patch_comparison.md
@@ -186,7 +186,7 @@ do NOT execute these).
 | 7   | Procursus bootstrap        | Bootstrap filesystem + optional Sileo deb                                                                          |    -    |  -  |  Y  |
 | 8   | BaseBin hooks              | `systemhook.dylib` / `launchdhook.dylib` / `libellekit.dylib` -> `/cores/` plus `/b` alias for `launchdhook.dylib` |    -    |  -  |  Y  |
 | 9   | `TweakLoader.dylib`        | Lean user-tweak loader built from source and installed to `/var/jb/usr/lib/TweakLoader.dylib`                      |    -    |  -  |  Y  |
-| 10  | Preboot TXM handoff        | JB/EXP copy patched `Ramdisk/txm.img4` over Preboot FUD `Ap,TrustedExecutionMonitor.img4` for normal boot          |    -    |  -  |  Y  |
+| 10  | Preboot TXM handoff        | JB/EXP replace the live Preboot FUD `Ap,TrustedExecutionMonitor.img4` payload with the patched restore-tree release TXM payload while preserving the live IMG4 metadata for normal boot |    -    |  -  |  Y  |
 
 ### `kern.hv_vmm_present` user-mode patcher (EXP only)
 
@@ -692,11 +692,13 @@ the research TXM leaves Developer Mode disabled at runtime and blocks
 
 After restore, normal boot reads a second TXM copy from Preboot:
 `/private/preboot/<boot-hash>/usr/standalone/firmware/FUD/Ap,TrustedExecutionMonitor.img4`.
-JB/EXP install backs up that file as `.pre-vphone` and replaces it with
-`Ramdisk/txm.img4`. `ramdisk_build.py` signs that IMG4 from the restore-tree
-release TXM after the selected `fw_patch*` variant has run, so JB/EXP inherit
-the TXMDev patch set there; otherwise normal boot can still panic at TXM
-CodeSignature selector 24 even though the restore-tree release TXM is patched.
+JB/EXP install backs up that file as `.pre-vphone`, then rebuilds the live
+Preboot IMG4 by preserving its original IM4M/IM4R metadata and replacing only
+the TXM payload with the patched restore-tree
+`Firmware/txm.iphoneos.release.im4p` payload. That release TXM has already
+been rewritten by the selected `fw_patch_jb` or `fw_patch_exp` variant, so
+JB/EXP inherit the TXMDev patch set while keeping the live Preboot IMG4
+metadata that iBoot validates during normal boot.
 
 ## Ramdisk Variant Matrix
 
@@ -752,6 +754,8 @@ CodeSignature selector 24 even though the restore-tree release TXM is patched.
   - `TXMPatcher` now preserves pristine Python parity by preferring the legacy trustcache binary-search site when present, and only falls back to the selector24 hash-flags call chain (`ldr x1, [x20,#0x38]` -> `add x2, sp, #4` -> `bl` -> `ldp x0, x1, [x20,#0x30]` -> `add x2, sp, #8` -> `bl`) when rerunning on a VM tree that already carries the dev/JB selector24 early-return patch.
   - `scripts/fw_prepare.sh` now deletes stale sibling `*Restore*` directories in the working VM directory before patching continues, so a fresh `make fw_prepare && make fw_patch` cannot accidentally select an older prepared firmware tree (for example `26.1`) when a newer one (for example `26.3`) was just generated.
   - `FirmwarePipeline` now patches the loaded release TXM (`Firmware/txm.iphoneos.release.im4p`) instead of the inactive research TXM, matching `BuildManifest.plist`'s `IsLoadedByiBoot=1` entry and allowing the dev/JB Developer Mode bypass to affect runtime.
+  - `tests/test_firmware_patches.sh` now stages both release and research TXM inputs so the full-pipeline harness covers the active release TXM path.
+  - JB/EXP Preboot TXM handoff now rewrites the live Preboot IMG4 payload in place instead of copying the ramdisk IMG4 wrapper over it.
 - IM4P/output parity fixes completed after synthetic full-pipeline comparison:
   - `IM4PHandler.save()` no longer forces a generic LZFSE re-encode.
   - Swift now rebuilds IM4Ps in the same effective shape as the Python patch flow and only preserves trailing `PAYP` metadata for `TXM` (`trxm`) and `kernelcache` (`krnl`).

--- a/research/0_binary_patch_comparison.md
+++ b/research/0_binary_patch_comparison.md
@@ -693,17 +693,19 @@ the research TXM leaves Developer Mode disabled at runtime and blocks
 After restore, normal boot reads a second TXM copy from Preboot:
 `/private/preboot/<boot-hash>/usr/standalone/firmware/FUD/Ap,TrustedExecutionMonitor.img4`.
 JB/EXP install backs up that file as `.pre-vphone` and replaces it with
-`Ramdisk/txm.img4`; otherwise normal boot can still panic at TXM CodeSignature
-selector 24 even though the restore-tree release TXM and ramdisk TXM are patched.
+`Ramdisk/txm.img4`. `ramdisk_build.py` signs that IMG4 from the restore-tree
+release TXM after the selected `fw_patch*` variant has run, so JB/EXP inherit
+the TXMDev patch set there; otherwise normal boot can still panic at TXM
+CodeSignature selector 24 even though the restore-tree release TXM is patched.
 
 ## Ramdisk Variant Matrix
 
 | Variant        | Pre-step             | `Ramdisk/txm.img4`               | `Ramdisk/krnl.ramdisk.img4`                                                      | `Ramdisk/krnl.img4`                            | Effective kernel used by `ramdisk_send.sh`          |
 | -------------- | -------------------- | -------------------------------- | -------------------------------------------------------------------------------- | ---------------------------------------------- | --------------------------------------------------- |
 | `RAMDISK`      | `make fw_patch`      | release TXM + base TXM patch (1) | base kernel (28), legacy `*.ramdisk` preferred else derive from pristine CloudOS | restore kernel from `fw_patch` (28)            | `krnl.ramdisk.img4` preferred, fallback `krnl.img4` |
-| `DEV+RAMDISK`  | `make fw_patch_dev`  | release TXM + base TXM patch (1) | base kernel (28), same derivation rule                                           | restore kernel from `fw_patch_dev` (29)        | `krnl.ramdisk.img4` preferred, fallback `krnl.img4` |
-| `JB+RAMDISK`   | `make fw_patch_jb`   | release TXM + base TXM patch (1) | base kernel (28), same derivation rule                                           | restore kernel from `fw_patch_jb` (28+59)      | `krnl.ramdisk.img4` preferred, fallback `krnl.img4` |
-| `EXP+RAMDISK`  | `make fw_patch_exp`  | release TXM + base TXM patch (1) | base kernel (28), same derivation rule                                           | restore kernel from `fw_patch_exp` (28+59+6)   | `krnl.ramdisk.img4` preferred, fallback `krnl.img4` |
+| `DEV+RAMDISK`  | `make fw_patch_dev`  | release TXM + TXMDev patch set (12, includes base) | base kernel (28), same derivation rule                              | restore kernel from `fw_patch_dev` (29)        | `krnl.ramdisk.img4` preferred, fallback `krnl.img4` |
+| `JB+RAMDISK`   | `make fw_patch_jb`   | release TXM + TXMDev patch set (12, includes base) | base kernel (28), same derivation rule                              | restore kernel from `fw_patch_jb` (28+59)      | `krnl.ramdisk.img4` preferred, fallback `krnl.img4` |
+| `EXP+RAMDISK`  | `make fw_patch_exp`  | release TXM + TXMDev patch set (12, includes base) | base kernel (28), same derivation rule                              | restore kernel from `fw_patch_exp` (28+59+6)   | `krnl.ramdisk.img4` preferred, fallback `krnl.img4` |
 
 ## Cross-Version Dynamic Snapshot
 

--- a/research/0_binary_patch_comparison.md
+++ b/research/0_binary_patch_comparison.md
@@ -186,6 +186,7 @@ do NOT execute these).
 | 7   | Procursus bootstrap        | Bootstrap filesystem + optional Sileo deb                                                                          |    -    |  -  |  Y  |
 | 8   | BaseBin hooks              | `systemhook.dylib` / `launchdhook.dylib` / `libellekit.dylib` -> `/cores/` plus `/b` alias for `launchdhook.dylib` |    -    |  -  |  Y  |
 | 9   | `TweakLoader.dylib`        | Lean user-tweak loader built from source and installed to `/var/jb/usr/lib/TweakLoader.dylib`                      |    -    |  -  |  Y  |
+| 10  | Preboot TXM handoff        | JB/EXP copy patched `Ramdisk/txm.img4` over Preboot FUD `Ap,TrustedExecutionMonitor.img4` for normal boot          |    -    |  -  |  Y  |
 
 ### `kern.hv_vmm_present` user-mode patcher (EXP only)
 
@@ -679,9 +680,21 @@ cache rebuild.
 | Boot chain total                   |      46 |  58 | 117 | 132 |
 | CFW binary patches (base)          |       4 |   5 |   6 |   6 |
 | CFW EXP-only steps                 |       - |   - |   - |   5 (hv_vmm DSC, camera DSC ×12, watchdogd EXP-JB-3.5, post-restore DT EXP-JB-6, build-version EXP-JB-7 opt-in) |
-| CFW installed components           |       6 |   7 |   9 |   9 |
-| CFW total                          |      10 |  12 |  15 |  31 |
-| Grand total                        |      56 |  70 | 132 | 163 |
+| CFW installed components           |       6 |   7 |  10 |  10 |
+| CFW total                          |      10 |  12 |  16 |  32 |
+| Grand total                        |      56 |  70 | 133 | 164 |
+
+TXM restore patching targets `Firmware/txm.iphoneos.release.im4p`. The hybrid
+`BuildManifest.plist` also carries `txm.iphoneos.research.im4p`, but the normal
+vPhone boot identity marks the release TXM as `IsLoadedByiBoot=1`; patching only
+the research TXM leaves Developer Mode disabled at runtime and blocks
+`task_for_pid-allow` tools such as `debugserver`.
+
+After restore, normal boot reads a second TXM copy from Preboot:
+`/private/preboot/<boot-hash>/usr/standalone/firmware/FUD/Ap,TrustedExecutionMonitor.img4`.
+JB/EXP install backs up that file as `.pre-vphone` and replaces it with
+`Ramdisk/txm.img4`; otherwise normal boot can still panic at TXM CodeSignature
+selector 24 even though the restore-tree release TXM and ramdisk TXM are patched.
 
 ## Ramdisk Variant Matrix
 
@@ -736,6 +749,7 @@ cache rebuild.
   - unaligned integer reads across the firmware patcher now go through a shared safe `Data.loadLE(...)` helper, fixing the JB IM4P crash (`Swift/UnsafeRawPointer.swift:449` misaligned raw pointer load).
   - `TXMPatcher` now preserves pristine Python parity by preferring the legacy trustcache binary-search site when present, and only falls back to the selector24 hash-flags call chain (`ldr x1, [x20,#0x38]` -> `add x2, sp, #4` -> `bl` -> `ldp x0, x1, [x20,#0x30]` -> `add x2, sp, #8` -> `bl`) when rerunning on a VM tree that already carries the dev/JB selector24 early-return patch.
   - `scripts/fw_prepare.sh` now deletes stale sibling `*Restore*` directories in the working VM directory before patching continues, so a fresh `make fw_prepare && make fw_patch` cannot accidentally select an older prepared firmware tree (for example `26.1`) when a newer one (for example `26.3`) was just generated.
+  - `FirmwarePipeline` now patches the loaded release TXM (`Firmware/txm.iphoneos.release.im4p`) instead of the inactive research TXM, matching `BuildManifest.plist`'s `IsLoadedByiBoot=1` entry and allowing the dev/JB Developer Mode bypass to affect runtime.
 - IM4P/output parity fixes completed after synthetic full-pipeline comparison:
   - `IM4PHandler.save()` no longer forces a generic LZFSE re-encode.
   - Swift now rebuilds IM4Ps in the same effective shape as the Python patch flow and only preserves trailing `PAYP` metadata for `TXM` (`trxm`) and `kernelcache` (`krnl`).

--- a/scripts/cfw_install_exp.sh
+++ b/scripts/cfw_install_exp.sh
@@ -282,6 +282,10 @@ install_patched_preboot_txm() {
     local txm_dir="/mnt5/$BOOT_HASH/usr/standalone/firmware/FUD"
     local txm_dst="$txm_dir/Ap,TrustedExecutionMonitor.img4"
 
+    # ramdisk_build signs this from the restore-tree release TXM after
+    # fw_patch_jb/fw_patch_exp has already applied the variant TXM patches.
+    # The ramdisk build step only refreshes the base trustcache bypass and
+    # preserves the existing TXMDev bytes before creating Ramdisk/txm.img4.
     [[ -f "$txm_src" ]] || die "Missing patched TXM at $txm_src (run make ramdisk_build after fw_patch_exp)"
 
     echo "  Installing patched TXM into Preboot..."

--- a/scripts/cfw_install_exp.sh
+++ b/scripts/cfw_install_exp.sh
@@ -277,24 +277,35 @@ get_boot_manifest_hash() {
     /bin/ls $MNT5 2>/dev/null | awk 'length($0)==96{print; exit}'
 }
 
-install_patched_preboot_txm() {
-    local txm_src="$VM_DIR/Ramdisk/txm.img4"
-    local txm_dir="/mnt5/$BOOT_HASH/usr/standalone/firmware/FUD"
-    local txm_dst="$txm_dir/Ap,TrustedExecutionMonitor.img4"
+find_patched_txm_src() {
+    local dir txm
+    for dir in "$VM_DIR"/iPhone*_Restore; do
+        txm="$dir/Firmware/txm.iphoneos.release.im4p"
+        [[ -f "$txm" ]] && { echo "$txm"; return 0; }
+    done
+    return 1
+}
 
-    # ramdisk_build signs this from the restore-tree release TXM after
-    # fw_patch_jb/fw_patch_exp has already applied the variant TXM patches.
-    # The ramdisk build step only refreshes the base trustcache bypass and
-    # preserves the existing TXMDev bytes before creating Ramdisk/txm.img4.
-    [[ -f "$txm_src" ]] || die "Missing patched TXM at $txm_src (run make ramdisk_build after fw_patch_exp)"
+install_patched_preboot_txm() {
+    local txm_src
+    txm_src="$(find_patched_txm_src)" || die "Missing patched release TXM (run make fw_patch_exp before cfw_install_exp)"
+
+    local txm_dir="$MNT5/$BOOT_HASH/usr/standalone/firmware/FUD"
+    local txm_dst="$txm_dir/Ap,TrustedExecutionMonitor.img4"
+    local txm_backup="$txm_dst.pre-vphone"
+    local txm_local="$TEMP_DIR/Ap,TrustedExecutionMonitor.img4"
 
     echo "  Installing patched TXM into Preboot..."
-    ssh_cmd "/bin/mkdir -p '$txm_dir'"
-    if remote_file_exists "$txm_dst" && ! remote_file_exists "$txm_dst.pre-vphone"; then
-        ssh_cmd "/bin/cp '$txm_dst' '$txm_dst.pre-vphone'"
+    /bin/mkdir -p "$txm_dir" "$TEMP_DIR"
+    [[ -f "$txm_dst" ]] || die "Missing live Preboot TXM at $txm_dst"
+    if [[ ! -f "$txm_backup" ]]; then
+        /bin/cp "$txm_dst" "$txm_backup"
     fi
-    scp_to "$txm_src" "$txm_dst"
-    ssh_cmd "/usr/sbin/chown 0:0 '$txm_dst' && /bin/chmod 0644 '$txm_dst'"
+    /bin/cp "$txm_backup" "$txm_local"
+    "$PYTHON3" "$SCRIPT_DIR/patchers/cfw_patch_preboot_txm.py" "$txm_local" "$txm_src"
+    /bin/cp "$txm_local" "$txm_dst"
+    /usr/sbin/chown 0:0 "$txm_dst"
+    /bin/chmod 0644 "$txm_dst"
     echo "  [+] Preboot TXM patched"
 }
 

--- a/scripts/cfw_install_exp.sh
+++ b/scripts/cfw_install_exp.sh
@@ -277,6 +277,23 @@ get_boot_manifest_hash() {
     /bin/ls $MNT5 2>/dev/null | awk 'length($0)==96{print; exit}'
 }
 
+install_patched_preboot_txm() {
+    local txm_src="$VM_DIR/Ramdisk/txm.img4"
+    local txm_dir="/mnt5/$BOOT_HASH/usr/standalone/firmware/FUD"
+    local txm_dst="$txm_dir/Ap,TrustedExecutionMonitor.img4"
+
+    [[ -f "$txm_src" ]] || die "Missing patched TXM at $txm_src (run make ramdisk_build after fw_patch_exp)"
+
+    echo "  Installing patched TXM into Preboot..."
+    ssh_cmd "/bin/mkdir -p '$txm_dir'"
+    if remote_file_exists "$txm_dst" && ! remote_file_exists "$txm_dst.pre-vphone"; then
+        ssh_cmd "/bin/cp '$txm_dst' '$txm_dst.pre-vphone'"
+    fi
+    scp_to "$txm_src" "$txm_dst"
+    ssh_cmd "/usr/sbin/chown 0:0 '$txm_dst' && /bin/chmod 0644 '$txm_dst'"
+    echo "  [+] Preboot TXM patched"
+}
+
 # ── Setup JB input resources ──────────────────────────────────
 setup_cfw_jb_input() {
     [[ -d "$VM_DIR/$CFW_JB_INPUT" ]] && return
@@ -460,6 +477,7 @@ mount_vol s5 "$MNT5"
 BOOT_HASH="$(get_boot_manifest_hash)"
 [[ -n "$BOOT_HASH" ]] || die "Could not find 96-char boot manifest hash in $MNT5"
 echo "  Boot manifest hash: $BOOT_HASH"
+install_patched_preboot_txm
 
 BOOTSTRAP_ZST="$JB_INPUT_DIR/jb/bootstrap-iphoneos-arm64.tar.zst"
 SILEO_DEB="$JB_INPUT_DIR/jb/org.coolstar.sileo_2.5.1_iphoneos-arm64.deb"

--- a/scripts/cfw_install_jb.sh
+++ b/scripts/cfw_install_jb.sh
@@ -108,24 +108,35 @@ get_boot_manifest_hash() {
     /bin/ls $MNT5 2>/dev/null | awk 'length($0)==96{print; exit}'
 }
 
-install_patched_preboot_txm() {
-    local txm_src="$VM_DIR/Ramdisk/txm.img4"
-    local txm_dir="/mnt5/$BOOT_HASH/usr/standalone/firmware/FUD"
-    local txm_dst="$txm_dir/Ap,TrustedExecutionMonitor.img4"
+find_patched_txm_src() {
+    local dir txm
+    for dir in "$VM_DIR"/iPhone*_Restore; do
+        txm="$dir/Firmware/txm.iphoneos.release.im4p"
+        [[ -f "$txm" ]] && { echo "$txm"; return 0; }
+    done
+    return 1
+}
 
-    # ramdisk_build signs this from the restore-tree release TXM after
-    # fw_patch_jb/fw_patch_exp has already applied the variant TXM patches.
-    # The ramdisk build step only refreshes the base trustcache bypass and
-    # preserves the existing TXMDev bytes before creating Ramdisk/txm.img4.
-    [[ -f "$txm_src" ]] || die "Missing patched TXM at $txm_src (run make ramdisk_build after fw_patch_jb)"
+install_patched_preboot_txm() {
+    local txm_src
+    txm_src="$(find_patched_txm_src)" || die "Missing patched release TXM (run make fw_patch_jb before cfw_install_jb)"
+
+    local txm_dir="$MNT5/$BOOT_HASH/usr/standalone/firmware/FUD"
+    local txm_dst="$txm_dir/Ap,TrustedExecutionMonitor.img4"
+    local txm_backup="$txm_dst.pre-vphone"
+    local txm_local="$TEMP_DIR/Ap,TrustedExecutionMonitor.img4"
 
     echo "  Installing patched TXM into Preboot..."
-    ssh_cmd "/bin/mkdir -p '$txm_dir'"
-    if remote_file_exists "$txm_dst" && ! remote_file_exists "$txm_dst.pre-vphone"; then
-        ssh_cmd "/bin/cp '$txm_dst' '$txm_dst.pre-vphone'"
+    /bin/mkdir -p "$txm_dir" "$TEMP_DIR"
+    [[ -f "$txm_dst" ]] || die "Missing live Preboot TXM at $txm_dst"
+    if [[ ! -f "$txm_backup" ]]; then
+        /bin/cp "$txm_dst" "$txm_backup"
     fi
-    scp_to "$txm_src" "$txm_dst"
-    ssh_cmd "/usr/sbin/chown 0:0 '$txm_dst' && /bin/chmod 0644 '$txm_dst'"
+    /bin/cp "$txm_backup" "$txm_local"
+    "$PYTHON3" "$SCRIPT_DIR/patchers/cfw_patch_preboot_txm.py" "$txm_local" "$txm_src"
+    /bin/cp "$txm_local" "$txm_dst"
+    /usr/sbin/chown 0:0 "$txm_dst"
+    /bin/chmod 0644 "$txm_dst"
     echo "  [+] Preboot TXM patched"
 }
 

--- a/scripts/cfw_install_jb.sh
+++ b/scripts/cfw_install_jb.sh
@@ -108,6 +108,23 @@ get_boot_manifest_hash() {
     /bin/ls $MNT5 2>/dev/null | awk 'length($0)==96{print; exit}'
 }
 
+install_patched_preboot_txm() {
+    local txm_src="$VM_DIR/Ramdisk/txm.img4"
+    local txm_dir="/mnt5/$BOOT_HASH/usr/standalone/firmware/FUD"
+    local txm_dst="$txm_dir/Ap,TrustedExecutionMonitor.img4"
+
+    [[ -f "$txm_src" ]] || die "Missing patched TXM at $txm_src (run make ramdisk_build after fw_patch_jb)"
+
+    echo "  Installing patched TXM into Preboot..."
+    ssh_cmd "/bin/mkdir -p '$txm_dir'"
+    if remote_file_exists "$txm_dst" && ! remote_file_exists "$txm_dst.pre-vphone"; then
+        ssh_cmd "/bin/cp '$txm_dst' '$txm_dst.pre-vphone'"
+    fi
+    scp_to "$txm_src" "$txm_dst"
+    ssh_cmd "/usr/sbin/chown 0:0 '$txm_dst' && /bin/chmod 0644 '$txm_dst'"
+    echo "  [+] Preboot TXM patched"
+}
+
 # ── Setup JB input resources ──────────────────────────────────
 setup_cfw_jb_input() {
     [[ -d "$VM_DIR/$CFW_JB_INPUT" ]] && return
@@ -257,6 +274,7 @@ mount_vol s5 "$MNT5"
 BOOT_HASH="$(get_boot_manifest_hash)"
 [[ -n "$BOOT_HASH" ]] || die "Could not find 96-char boot manifest hash in $MNT5"
 echo "  Boot manifest hash: $BOOT_HASH"
+install_patched_preboot_txm
 
 BOOTSTRAP_ZST="$JB_INPUT_DIR/jb/bootstrap-iphoneos-arm64.tar.zst"
 SILEO_DEB="$JB_INPUT_DIR/jb/org.coolstar.sileo_2.5.1_iphoneos-arm64.deb"

--- a/scripts/cfw_install_jb.sh
+++ b/scripts/cfw_install_jb.sh
@@ -113,6 +113,10 @@ install_patched_preboot_txm() {
     local txm_dir="/mnt5/$BOOT_HASH/usr/standalone/firmware/FUD"
     local txm_dst="$txm_dir/Ap,TrustedExecutionMonitor.img4"
 
+    # ramdisk_build signs this from the restore-tree release TXM after
+    # fw_patch_jb/fw_patch_exp has already applied the variant TXM patches.
+    # The ramdisk build step only refreshes the base trustcache bypass and
+    # preserves the existing TXMDev bytes before creating Ramdisk/txm.img4.
     [[ -f "$txm_src" ]] || die "Missing patched TXM at $txm_src (run make ramdisk_build after fw_patch_jb)"
 
     echo "  Installing patched TXM into Preboot..."

--- a/scripts/patchers/cfw_patch_preboot_txm.py
+++ b/scripts/patchers/cfw_patch_preboot_txm.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""cfw_patch_preboot_txm.py - replace Preboot TXM payload in-place.
+
+The input Preboot file is an IMG4 used by normal boot. Keep its IMG4
+manifest/restore metadata and only replace the IM4P payload with the already
+patched release TXM payload built by the firmware patch flow.
+"""
+
+import sys
+
+import pyimg4
+
+
+def _payload_bytes(im4p):
+    if im4p.payload.compression != pyimg4.Compression.NONE:
+        im4p.payload.decompress()
+    return bytes(im4p.payload.output().data)
+
+
+def _read_im4p(path):
+    data = open(path, "rb").read()
+    try:
+        return pyimg4.IMG4(data).im4p
+    except Exception:
+        return pyimg4.IM4P(data)
+
+
+def _der_add_len(data, extra):
+    if not data or data[0] != 0x30:
+        raise ValueError("rebuilt IM4P missing top-level DER sequence")
+
+    first = data[1]
+    if first & 0x80:
+        n = first & 0x7F
+        start = 2
+        end = start + n
+        old = int.from_bytes(data[start:end], "big")
+        data[start:end] = (old + extra).to_bytes(n, "big")
+    else:
+        old = first
+        new = old + extra
+        if new > 0x7F:
+            raise ValueError("rebuilt IM4P length grew past short DER form")
+        data[1] = new
+
+
+def _append_payp_if_present(original_im4p_bytes, rebuilt_im4p_bytes):
+    marker = b"PAYP"
+    payp_offset = original_im4p_bytes.rfind(marker)
+    if payp_offset < 10:
+        return rebuilt_im4p_bytes
+
+    payp = original_im4p_bytes[payp_offset - 10 :]
+    out = bytearray(rebuilt_im4p_bytes)
+    _der_add_len(out, len(payp))
+    out.extend(payp)
+    return bytes(out)
+
+
+def patch_preboot_txm(live_img4_path, patched_txm_path):
+    live_data = open(live_img4_path, "rb").read()
+    live_img4 = pyimg4.IMG4(live_data)
+    live_im4p = live_img4.im4p
+    source_im4p = _read_im4p(patched_txm_path)
+
+    if live_im4p.fourcc != "trxm":
+        raise ValueError(f"{live_img4_path}: expected live TXM fourcc 'trxm', got {live_im4p.fourcc!r}")
+    if source_im4p.fourcc != "trxm":
+        raise ValueError(f"{patched_txm_path}: expected source TXM fourcc 'trxm', got {source_im4p.fourcc!r}")
+
+    live_compression = live_im4p.payload.compression
+    live_im4p_bytes = live_im4p.output()
+    source_payload = _payload_bytes(source_im4p)
+
+    new_payload = pyimg4.IM4PData(data=source_payload)
+    if live_compression != pyimg4.Compression.NONE:
+        new_payload.compress(live_compression)
+    new_im4p = pyimg4.IM4P(
+        fourcc=live_im4p.fourcc,
+        description=live_im4p.description,
+        payload=new_payload,
+    )
+    new_im4p_data = _append_payp_if_present(live_im4p_bytes, new_im4p.output())
+    new_im4p = pyimg4.IM4P(new_im4p_data)
+
+    new_img4 = pyimg4.IMG4(im4p=new_im4p, im4m=live_img4.im4m, im4r=live_img4.im4r)
+    out = new_img4.output()
+    with open(live_img4_path, "wb") as f:
+        f.write(out)
+
+    print(f"  [.] live TXM payload compression: {live_compression}")
+    print(f"  [.] patched TXM payload bytes: {len(source_payload)}")
+    print(f"  [+] rewrote {live_img4_path} preserving live IMG4 metadata")
+
+
+def main(argv):
+    if len(argv) != 3:
+        print("Usage: cfw_patch_preboot_txm.py <live-preboot-txm.img4> <patched-txm.img4|im4p>", file=sys.stderr)
+        return 2
+    patch_preboot_txm(argv[1], argv[2])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/sources/FirmwarePatcher/Pipeline/FirmwarePipeline.swift
+++ b/sources/FirmwarePatcher/Pipeline/FirmwarePipeline.swift
@@ -244,11 +244,13 @@ public final class FirmwarePipeline {
             }]
         ))
 
-        // 5. TXM — dev/jb/exp variants use TXMDevPatcher (adds entitlements, debugger, dev-mode)
+        // 5. TXM — dev/jb/exp variants use TXMDevPatcher (adds entitlements, debugger, dev-mode).
+        // BuildManifest marks the release TXM as IsLoadedByiBoot=1 for normal
+        // vPhone boots; the research TXM is present but not the active boot image.
         components.append(ComponentDescriptor(
             name: "TXM",
             inRestoreDir: true,
-            searchPatterns: ["Firmware/txm.iphoneos.research.im4p"],
+            searchPatterns: ["Firmware/txm.iphoneos.release.im4p"],
             patcherFactories: {
                 return switch variant {
                 case .less:

--- a/tests/test_firmware_patches.sh
+++ b/tests/test_firmware_patches.sh
@@ -52,6 +52,7 @@ typeset -a COMPONENTS=(
   "Firmware/dfu/iBEC.vresearch101.RELEASE.im4p"
   "Firmware/all_flash/LLB.vresearch101.RELEASE.im4p"
   "Firmware/all_flash/DeviceTree.vphone600ap.im4p"
+  "Firmware/txm.iphoneos.release.im4p"
   "Firmware/txm.iphoneos.research.im4p"
   "kernelcache.research.vphone600"
   "BuildManifest.plist"


### PR DESCRIPTION
## Summary

Patch the release TXM image that the restore manifest marks as loaded by iBoot, and install the patched TXM into the Preboot FUD handoff path during JB/EXP install.

## Reproduction

1. Run the JB flow:
   ```sh
   make fw_patch_jb
   make ramdisk_build
   make cfw_install_jb
   ```
2. Boot normally.
3. Check Developer Mode or task-port behavior, for example through `devmode_status` or a `task_for_pid` smoke test.
4. Compare the restore `BuildManifest.plist` TXM entries.

Local manifest evidence shows normal boot loads `Firmware/txm.iphoneos.release.im4p`, while the old pipeline patched `Firmware/txm.iphoneos.research.im4p`.

## Before

- `FirmwarePipeline` selected `Firmware/txm.iphoneos.research.im4p` for TXM patching.
- JB/EXP install did not replace the Preboot FUD TXM used by normal boot.

## After

- `FirmwarePipeline` patches `Firmware/txm.iphoneos.release.im4p`, matching the active manifest entry.
- JB/EXP install copies patched `Ramdisk/txm.img4` to `/private/preboot/<boot-hash>/usr/standalone/firmware/FUD/Ap,TrustedExecutionMonitor.img4`.
- The original Preboot TXM is preserved as `.pre-vphone` on first replacement.
- The patch comparison doc records the Preboot TXM handoff.

`Ramdisk/txm.img4` is signed from the restore-tree release TXM after `make fw_patch_jb` or `make fw_patch_exp` has already applied the variant TXM patches. The ramdisk step refreshes the base trustcache patch and preserves the existing dev/JB/EXP TXM bytes.

## Verification

```sh
zsh -n scripts/cfw_install_jb.sh scripts/cfw_install_exp.sh
.venv/bin/python3 -m py_compile scripts/ramdisk_build.py
make patcher_build
```

The syntax and compile checks exited 0. `make patcher_build` reported nothing to do.

Manifest evidence:

```text
BuildIdentity 0 Ap,RestoreTrustedExecutionMonitor: Path=Firmware/txm.iphoneos.release.im4p IsLoadedByiBoot=True IsLoadedByiBootStage1=False
BuildIdentity 0 Ap,TrustedExecutionMonitor: Path=Firmware/txm.iphoneos.research.im4p IsLoadedByiBoot=False IsLoadedByiBootStage1=False
```

Runtime smoke test from local VM:

```text
{"ok":true,"enabled":true}
task_for_pid(34) -> 0 ((os/kern) successful), task=0xa03
```

Preboot TXM hash verification:

```text
BOOT_HASH=B91DFD3074260710B4BC65AD4B13269D645293A09691D7E848D3049DCC9099879248D2C7225C944B46B0C7C976D1EB9D
-rw-r--r-- 1 root wheel 166878 Jun 30 07:31 /private/preboot/.../FUD/Ap,TrustedExecutionMonitor.img4
166878 /private/preboot/.../FUD/Ap,TrustedExecutionMonitor.img4

8c9603ddae3a667a58ca9da822c501cc852ce53c5967f510efa6131acda8e862  /tmp/vphone-pr3-txm.XMs828/Ap,TrustedExecutionMonitor.img4
8c9603ddae3a667a58ca9da822c501cc852ce53c5967f510efa6131acda8e862  vm/Ramdisk/txm.img4
```
