### PR TITLE
Harden install image handling and first-boot setup

### DIFF
--- a/scripts/cfw_install.sh
+++ b/scripts/cfw_install.sh
@@ -150,11 +150,24 @@ ldid_sign() {
     ldid "${args[@]}" "$file"
 }
 
+host_hdiutil() {
+    local rc
+    hdiutil "$@" && return 0
+    rc=$?
+
+    if sudo -n true 2>/dev/null; then
+        sudo hdiutil "$@"
+        return
+    fi
+
+    return "$rc"
+}
+
 # Detach a DMG mountpoint if currently mounted, ignore errors
 safe_detach() {
     local mnt="$1"
     if mount | grep -Fq " on $mnt "; then
-        sudo hdiutil detach -force "$mnt" 2>/dev/null || true
+        host_hdiutil detach -force "$mnt" 2>/dev/null || true
     fi
 }
 
@@ -329,9 +342,11 @@ else
     assert_mount_under_vm "$MNT_APPOS" "AppOS mountpoint"
 
     echo "  Mounting SystemOS..."
-    sudo hdiutil attach -mountpoint "$MNT_SYSOS" "$SYSOS_DMG" -nobrowse -owners off
+    host_hdiutil attach -mountpoint "$MNT_SYSOS" "$SYSOS_DMG" -nobrowse -owners off \
+        || die "Failed to mount SystemOS DMG. Run 'sudo -v' in a terminal and retry if hdiutil needs administrator privileges."
     echo "  Mounting AppOS..."
-    sudo hdiutil attach -mountpoint "$MNT_APPOS" "$APPOS_DMG" -nobrowse -owners off
+    host_hdiutil attach -mountpoint "$MNT_APPOS" "$APPOS_DMG" -nobrowse -owners off \
+        || die "Failed to mount AppOS DMG. Run 'sudo -v' in a terminal and retry if hdiutil needs administrator privileges."
 
     ssh_cmd "/bin/rm -rf /mnt1/System/Cryptexes/App /mnt1/System/Cryptexes/OS"
     ssh_cmd "/bin/mkdir -p /mnt1/System/Cryptexes/App /mnt1/System/Cryptexes/OS"

--- a/scripts/ramdisk_build.py
+++ b/scripts/ramdisk_build.py
@@ -158,15 +158,26 @@ def run(cmd, **kwargs):
 
 
 def run_sudo(cmd, **kwargs):
-    """Run sudo command non-interactively using VPHONE_SUDO_PASSWORD."""
-    if SUDO_PASSWORD:
-        return run(
-            ["sudo", "-S", *cmd],
-            input=f"{SUDO_PASSWORD}\n",
-            text=True,
-            **kwargs,
-        )
-    return run(["sudo", *cmd], **kwargs)
+    """Run a command directly first, then retry through sudo if required."""
+    try:
+        return run(cmd, **kwargs)
+    except subprocess.CalledProcessError:
+        if SUDO_PASSWORD:
+            return run(
+                ["sudo", "-S", *cmd],
+                input=f"{SUDO_PASSWORD}\n",
+                text=True,
+                **kwargs,
+            )
+        return run(["sudo", *cmd], **kwargs)
+
+
+def detach_mountpoint(mountpoint):
+    """Best-effort detach for hdiutil mountpoints used during ramdisk builds."""
+    subprocess.run(
+        ["hdiutil", "detach", "-force", mountpoint],
+        capture_output=True,
+    )
 
 
 def ensure_path_within_vm(path, vm_dir, label):
@@ -490,6 +501,8 @@ def build_ramdisk(restore_dir, im4m_path, vm_dir, input_dir, output_dir, temp_di
 
     ensure_path_within_vm(mountpoint, vm_dir, "Ramdisk mountpoint")
     os.makedirs(mountpoint, exist_ok=True)
+    if os.path.exists(ramdisk_custom):
+        os.remove(ramdisk_custom)
 
     try:
         # Mount, create expanded copy
@@ -529,7 +542,7 @@ def build_ramdisk(restore_dir, im4m_path, vm_dir, input_dir, output_dir, temp_di
                 ramdisk_custom,
             ]
         )
-        run_sudo(["hdiutil", "detach", "-force", mountpoint])
+        detach_mountpoint(mountpoint)
 
         # Mount expanded, inject SSH
         print("  Mounting expanded ramdisk...")
@@ -606,7 +619,7 @@ def build_ramdisk(restore_dir, im4m_path, vm_dir, input_dir, output_dir, temp_di
         print(f"  [+] trustcache.img4")
 
     finally:
-        run_sudo(["hdiutil", "detach", "-force", mountpoint], capture_output=True)
+        detach_mountpoint(mountpoint)
 
     # Shrink and sign ramdisk
     run_sudo(["hdiutil", "resize", "-sectors", "min", ramdisk_custom])

--- a/scripts/ramdisk_build.py
+++ b/scripts/ramdisk_build.py
@@ -158,7 +158,10 @@ def run(cmd, **kwargs):
 
 
 def run_sudo(cmd, **kwargs):
-    """Run a command directly first, then retry through sudo if required."""
+    """Run hdiutil directly first, then retry through sudo if required."""
+    if not cmd or os.path.basename(cmd[0]) != "hdiutil":
+        return run(cmd, **kwargs)
+
     try:
         return run(cmd, **kwargs)
     except subprocess.CalledProcessError:
@@ -172,12 +175,13 @@ def run_sudo(cmd, **kwargs):
         return run(["sudo", *cmd], **kwargs)
 
 
-def detach_mountpoint(mountpoint):
-    """Best-effort detach for hdiutil mountpoints used during ramdisk builds."""
-    subprocess.run(
-        ["hdiutil", "detach", "-force", mountpoint],
-        capture_output=True,
-    )
+def detach_mountpoint(mountpoint, required=False):
+    """Detach hdiutil mountpoints used during ramdisk builds."""
+    try:
+        run_sudo(["hdiutil", "detach", "-force", mountpoint], capture_output=True)
+    except subprocess.CalledProcessError:
+        if required:
+            raise
 
 
 def ensure_path_within_vm(path, vm_dir, label):
@@ -542,7 +546,7 @@ def build_ramdisk(restore_dir, im4m_path, vm_dir, input_dir, output_dir, temp_di
                 ramdisk_custom,
             ]
         )
-        detach_mountpoint(mountpoint)
+        detach_mountpoint(mountpoint, required=True)
 
         # Mount expanded, inject SSH
         print("  Mounting expanded ramdisk...")

--- a/scripts/vphone_jb_setup.sh
+++ b/scripts/vphone_jb_setup.sh
@@ -97,7 +97,7 @@ chown -R 501:501 /var/jb/var/mobile/Library
 chmod 0755 /var/jb/var/mobile/Library
 chown -R 501:501 /var/jb/var/mobile/Library/Preferences
 chmod 0755 /var/jb/var/mobile/Library/Preferences
-chown -R 0:0 /var/jb/Library
+chown 0:0 /var/jb/Library /var/jb/Library/MobileSubstrate /var/jb/Library/MobileSubstrate/DynamicLibraries
 chmod 0755 /var/jb/Library /var/jb/Library/MobileSubstrate /var/jb/Library/MobileSubstrate/DynamicLibraries
 log "  Ownership set"
 
@@ -184,8 +184,10 @@ log "  apt upgrade done"
 
 # ═══════════ 7/7 INSTALL TROLLSTORE LITE ═════════════════════
 log "[7/8] Installing TrollStore Lite..."
+TROLLSTORE_READY=0
 if dpkg -s com.opa334.trollstorelite >/dev/null 2>&1; then
     log "  TrollStore Lite already installed"
+    TROLLSTORE_READY=1
 else
     apt-get -o APT::Get::AllowUnauthenticated=true \
         install -y -qq com.opa334.trollstorelite 2>&1
@@ -195,6 +197,7 @@ else
     else
         if dpkg -s com.opa334.trollstorelite >/dev/null 2>&1; then
             log "  TrollStore Lite installed"
+            TROLLSTORE_READY=1
         else
             log "  WARNING: TrollStore Lite install completed without registering package"
         fi
@@ -219,5 +222,9 @@ for profile in /var/root/.bashrc /var/root/.bash_profile; do
 done
 
 # ═══════════ DONE ════════════════════════════════════════════
-: > "$DONE_MARKER"
-log "=== vphone_jb_setup.sh complete ==="
+if [ "$TROLLSTORE_READY" = "1" ]; then
+    : > "$DONE_MARKER"
+    log "=== vphone_jb_setup.sh complete ==="
+else
+    log "=== vphone_jb_setup.sh core steps complete; TrollStore Lite still pending, marker not written ==="
+fi

--- a/scripts/vphone_jb_setup.sh
+++ b/scripts/vphone_jb_setup.sh
@@ -92,10 +92,13 @@ fi
 # ═══════════ 2/7 FIX OWNERSHIP / PERMISSIONS ═════════════════
 log "[2/8] Fixing mobile Library ownership..."
 mkdir -p /var/jb/var/mobile/Library/Preferences
+mkdir -p /var/jb/Library/MobileSubstrate/DynamicLibraries
 chown -R 501:501 /var/jb/var/mobile/Library
 chmod 0755 /var/jb/var/mobile/Library
 chown -R 501:501 /var/jb/var/mobile/Library/Preferences
 chmod 0755 /var/jb/var/mobile/Library/Preferences
+chown -R 0:0 /var/jb/Library
+chmod 0755 /var/jb/Library /var/jb/Library/MobileSubstrate /var/jb/Library/MobileSubstrate/DynamicLibraries
 log "  Ownership set"
 
 # ═══════════ 3/7 RUN prep_bootstrap.sh ═══════════════════════
@@ -188,12 +191,13 @@ else
         install -y -qq com.opa334.trollstorelite 2>&1
     trollstore_rc=$?
     if [ "$trollstore_rc" -ne 0 ]; then
-        die "TrollStore Lite apt install failed with exit code $trollstore_rc"
-    fi
-    if dpkg -s com.opa334.trollstorelite >/dev/null 2>&1; then
-        log "  TrollStore Lite installed"
+        log "  WARNING: TrollStore Lite apt install failed with exit code $trollstore_rc"
     else
-        die "TrollStore Lite install completed without registering package"
+        if dpkg -s com.opa334.trollstorelite >/dev/null 2>&1; then
+            log "  TrollStore Lite installed"
+        else
+            log "  WARNING: TrollStore Lite install completed without registering package"
+        fi
     fi
 fi
 


### PR DESCRIPTION
## Summary

Combine two setup reliability fixes:

- Avoid unnecessary `sudo hdiutil` usage and stale ramdisk image state during host-side install/ramdisk work.
- Harden first-boot JB setup so optional TrollStore Lite failure does not abort the script, while the done marker is withheld until TrollStore Lite is actually ready.

## Reproduction: host image handling

1. Run `make cfw_install` from a non-interactive environment without cached sudo credentials.
2. When Cryptex DMGs are mounted, the old script calls `sudo hdiutil` directly and can block on a password prompt.
3. Separately, interrupt or re-run `make ramdisk_build` after a previous failed attempt. A stale `SSHRD` mount or existing `ramdisk1.dmg` can break the next run.

## Reproduction: first-boot setup

1. Install JB CFW and boot normally.
2. Make optional TrollStore Lite install unavailable or let apt fail.
3. Let `/cores/vphone_jb_setup.sh` run.
4. The script should continue through shell profile setup and leave expected tweak directories present.
5. The done marker should not be written until TrollStore Lite is installed or already registered.

## Before

- `cfw_install.sh` unconditionally called `sudo hdiutil` for Cryptex attach/detach.
- `ramdisk_build.py` always tried sudo for helper commands and could reuse/fail on a stale `ramdisk1.dmg`.
- Required ramdisk detach failures could be hidden.
- TrollStore Lite failure could leave finalization state ambiguous.
- `/var/jb/Library/MobileSubstrate/DynamicLibraries` was not guaranteed to exist.

## After

- `cfw_install.sh` tries plain `hdiutil` first, then falls back to noninteractive sudo only if a sudo credential is already available.
- Failure messages tell the user to run `sudo -v` explicitly if admin privileges are needed.
- `ramdisk_build.py` only applies sudo fallback to `hdiutil`, removes stale `ramdisk1.dmg`, and raises required detach failures.
- TrollStore Lite failure is logged as a warning; shell profile setup still runs.
- The done marker is only written when TrollStore Lite is ready.
- MobileSubstrate tweak directories are created with root-owned 0755 permissions.

## Verification

```sh
zsh -n scripts/cfw_install.sh
bash -n scripts/vphone_jb_setup.sh
.venv/bin/python3 -m py_compile scripts/ramdisk_build.py
git rev-list --left-right --count upstream/main...HEAD
```

Key output:

```text
0	3
```

The syntax and Python compile commands were silent and exited 0.

Old noninteractive sudo behavior:

```text
sudo: a password is required
sudo_noninteractive_rc:1
```

Old code evidence:

```text
153 # Detach a DMG mountpoint if currently mounted, ignore errors
157     sudo hdiutil detach -force "$mnt" 2>/dev/null || true
333 echo "  Mounting AppOS..."
334 sudo hdiutil attach -mountpoint "$MNT_APPOS" "$APPOS_DMG" -nobrowse -owners off
```

New code evidence:

```text
153 host_hdiutil() {
155     hdiutil "$@" && return 0
158     if sudo -n true 2>/dev/null; then
159         sudo hdiutil "$@"
163     return "$rc"
345 host_hdiutil attach -mountpoint "$MNT_SYSOS" "$SYSOS_DMG" -nobrowse -owners off \
346     || die "Failed to mount SystemOS DMG. Run 'sudo -v' in a terminal and retry if hdiutil needs administrator privileges."

160 def run_sudo(cmd, **kwargs):
161     """Run hdiutil directly first, then retry through sudo if required."""
162     if not cmd or os.path.basename(cmd[0]) != "hdiutil":
163         return run(cmd, **kwargs)
178 def detach_mountpoint(mountpoint, required=False):
181         run_sudo(["hdiutil", "detach", "-force", mountpoint], capture_output=True)
183         if required:
184             raise
508 if os.path.exists(ramdisk_custom):
509     os.remove(ramdisk_custom)
549         detach_mountpoint(mountpoint, required=True)
```

First-boot control-flow simulation:

The VM was not running during final review, so the current branch was validated with a path-rewritten local simulation. The temporary copy rewrites guest absolute paths to a `mktemp` root and fakes `apt-get`, `dpkg`, `chown`, and `uicache`; `apt-get install com.opa334.trollstorelite` returns 100.

Key output:

```text
[17:51:38] [7/8] Installing TrollStore Lite...
[17:51:38]   WARNING: TrollStore Lite apt install failed with exit code 100
[17:51:38]   uicache refreshed
[17:51:38] [8/8] Setting up shell profiles for SSH...
[17:51:38]   /tmp/.../root/private/var/root/.bashrc created
[17:51:38]   /tmp/.../root/private/var/root/.bash_profile created
[17:51:38] === vphone_jb_setup.sh core steps complete; TrollStore Lite still pending, marker not written ===
SIM_RC:0
DONE_MARKER:absent
MOBILESUBSTRATE_DIR:present
```
