### PR TITLE
Generate dropbear host keys with ramdisk's trustcached dropbearkey

### DIFF
--- a/scripts/cfw_install.sh
+++ b/scripts/cfw_install.sh
@@ -428,8 +428,8 @@ ssh_cmd "/bin/rm -f /mnt1/iosbinpack64.tar"
 
 echo "  Preparing dropbear host keys on Data volume..."
 ssh_cmd "/bin/mkdir -p /mnt3/dropbear"
-ssh_cmd "if [ ! -f /mnt3/dropbear/dropbear_rsa_host_key ]; then /mnt1/iosbinpack64/usr/local/bin/dropbearkey -t rsa -f /mnt3/dropbear/dropbear_rsa_host_key >/dev/null; fi"
-ssh_cmd "if [ ! -f /mnt3/dropbear/dropbear_ecdsa_host_key ]; then /mnt1/iosbinpack64/usr/local/bin/dropbearkey -t ecdsa -f /mnt3/dropbear/dropbear_ecdsa_host_key >/dev/null; fi"
+ssh_cmd "if [ ! -f /mnt3/dropbear/dropbear_rsa_host_key ]; then /usr/local/bin/dropbearkey -t rsa -f /mnt3/dropbear/dropbear_rsa_host_key >/dev/null; fi"
+ssh_cmd "if [ ! -f /mnt3/dropbear/dropbear_ecdsa_host_key ]; then /usr/local/bin/dropbearkey -t ecdsa -f /mnt3/dropbear/dropbear_ecdsa_host_key >/dev/null; fi"
 ssh_cmd "/bin/chmod 600 /mnt3/dropbear/dropbear_rsa_host_key /mnt3/dropbear/dropbear_ecdsa_host_key"
 
 echo "  [+] iosbinpack64 installed"

--- a/scripts/cfw_install_dev.sh
+++ b/scripts/cfw_install_dev.sh
@@ -417,8 +417,8 @@ ssh_cmd "/bin/rm -f /mnt1/iosbinpack64.tar"
 
 echo "  Preparing dropbear host keys on Data volume..."
 ssh_cmd "/bin/mkdir -p /mnt3/dropbear"
-ssh_cmd "if [ ! -f /mnt3/dropbear/dropbear_rsa_host_key ]; then /mnt1/iosbinpack64/usr/local/bin/dropbearkey -t rsa -f /mnt3/dropbear/dropbear_rsa_host_key >/dev/null; fi"
-ssh_cmd "if [ ! -f /mnt3/dropbear/dropbear_ecdsa_host_key ]; then /mnt1/iosbinpack64/usr/local/bin/dropbearkey -t ecdsa -f /mnt3/dropbear/dropbear_ecdsa_host_key >/dev/null; fi"
+ssh_cmd "if [ ! -f /mnt3/dropbear/dropbear_rsa_host_key ]; then /usr/local/bin/dropbearkey -t rsa -f /mnt3/dropbear/dropbear_rsa_host_key >/dev/null; fi"
+ssh_cmd "if [ ! -f /mnt3/dropbear/dropbear_ecdsa_host_key ]; then /usr/local/bin/dropbearkey -t ecdsa -f /mnt3/dropbear/dropbear_ecdsa_host_key >/dev/null; fi"
 ssh_cmd "/bin/chmod 600 /mnt3/dropbear/dropbear_rsa_host_key /mnt3/dropbear/dropbear_ecdsa_host_key"
 
 echo "  [+] iosbinpack64 installed"


### PR DESCRIPTION
The ramdisk-time host-key pre-seed added in c6ed3a1 invoked /mnt1/iosbinpack64/usr/local/bin/dropbearkey, an iPhone-Distribution-signed third-party binary. Inside the SSH ramdisk its cdhash is in no active trust cache, so AMFI SIGKILLs it (exit 137), aborting cfw_install_jb/dev.

Use the ramdisk's own /usr/local/bin/dropbearkey (from ssh.tar.gz, re-signed and trustcached at build time), which runs and writes fresh keys to the same Data-volume target. The first-boot generator in vphone_jb_setup.sh is unaffected — it runs in the JB'd kernel where the iosbinpack64 binary is valid.