### PR TITLE
cfw/ramdisk: route hdiutil straight to sudo -A when SUDO_ASKPASS is set

### DIFF
--- a/scripts/cfw_install.sh
+++ b/scripts/cfw_install.sh
@@ -152,6 +152,10 @@ ldid_sign() {
 
 host_hdiutil() {
     local rc
+    # SUDO_PASSWORD flow exports SUDO_ASKPASS: go straight to sudo -A so
+    # hdiutil never runs unprivileged first (which triggers an auth prompt).
+    [[ -n "${SUDO_ASKPASS:-}" ]] && { sudo -A hdiutil "$@"; return; }
+
     hdiutil "$@" && return 0
     rc=$?
 

--- a/scripts/cfw_install_dev.sh
+++ b/scripts/cfw_install_dev.sh
@@ -122,7 +122,7 @@ ldid_sign_ent() {
 safe_detach() {
     local mnt="$1"
     if mount | grep -Fq " on $mnt "; then
-        sudo hdiutil detach -force "$mnt" 2>/dev/null || true
+        sudo ${SUDO_ASKPASS:+-A} hdiutil detach -force "$mnt" 2>/dev/null || true
     fi
 }
 
@@ -275,9 +275,9 @@ assert_mount_under_vm "$MNT_SYSOS" "SystemOS mountpoint"
 assert_mount_under_vm "$MNT_APPOS" "AppOS mountpoint"
 
 echo "  Mounting SystemOS..."
-sudo hdiutil attach -mountpoint "$MNT_SYSOS" "$SYSOS_DMG" -nobrowse -owners off
+sudo ${SUDO_ASKPASS:+-A} hdiutil attach -mountpoint "$MNT_SYSOS" "$SYSOS_DMG" -nobrowse -owners off
 echo "  Mounting AppOS..."
-sudo hdiutil attach -mountpoint "$MNT_APPOS" "$APPOS_DMG" -nobrowse -owners off
+sudo ${SUDO_ASKPASS:+-A} hdiutil attach -mountpoint "$MNT_APPOS" "$APPOS_DMG" -nobrowse -owners off
 
 # Mount device rootfs (tolerate already-mounted)
 echo "  Mounting device rootfs rw..."

--- a/scripts/cfw_install_exp.sh
+++ b/scripts/cfw_install_exp.sh
@@ -93,8 +93,8 @@ if [[ -f "$JB_SYSOS_DMG" ]]; then
     # refuses pre-patched function entries unless --force is passed).
     echo "[*] DSC patches: mounting cached SystemOS DMG..."
     mkdir -p "$JB_MNT_SYSOS"
-    sudo hdiutil detach "$JB_MNT_SYSOS" -force 2>/dev/null || true
-    sudo hdiutil attach -mountpoint "$JB_MNT_SYSOS" "$JB_SYSOS_DMG" -nobrowse -owners off
+    sudo ${SUDO_ASKPASS:+-A} hdiutil detach "$JB_MNT_SYSOS" -force 2>/dev/null || true
+    sudo ${SUDO_ASKPASS:+-A} hdiutil attach -mountpoint "$JB_MNT_SYSOS" "$JB_SYSOS_DMG" -nobrowse -owners off
 
     JB_DSC_CHUNKS_DIR="$JB_MNT_SYSOS/System/Library/Caches/com.apple.dyld"
     JB_DSC_HEADER="$JB_DSC_CHUNKS_DIR/dyld_shared_cache_arm64e"
@@ -128,7 +128,7 @@ if [[ -f "$JB_SYSOS_DMG" ]]; then
         echo "[-] DSC patches: $JB_DSC_CHUNKS_DIR not found, skipping"
     fi
 
-    sudo hdiutil detach "$JB_MNT_SYSOS" -force
+    sudo ${SUDO_ASKPASS:+-A} hdiutil detach "$JB_MNT_SYSOS" -force
 fi
 
 # Now run the regular CFW install. It will see the cached (patched)

--- a/scripts/ramdisk_build.py
+++ b/scripts/ramdisk_build.py
@@ -162,6 +162,11 @@ def run_sudo(cmd, **kwargs):
     if not cmd or os.path.basename(cmd[0]) != "hdiutil":
         return run(cmd, **kwargs)
 
+    # SUDO_PASSWORD flow exports SUDO_ASKPASS: go straight to sudo -A so
+    # hdiutil never runs unprivileged first (which triggers an auth prompt).
+    if os.environ.get("SUDO_ASKPASS"):
+        return run(["sudo", "-A", *cmd], **kwargs)
+
     try:
         return run(cmd, **kwargs)
     except subprocess.CalledProcessError:


### PR DESCRIPTION
When SUDO_PASSWORD is supplied, setup_machine.sh exports SUDO_ASKPASS. Previously hdiutil ran unprivileged first (cfw_install.sh, ramdisk_build.py) or via plain interactive sudo (cfw_install_dev/exp.sh), both of which triggered a password prompt.

Now, when SUDO_ASKPASS is present, hdiutil goes straight to `sudo -A` so it never runs unprivileged first and never prompts. When it is absent, every call site keeps its original behavior verbatim.