### PR TITLE
Fix Patchless Pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,7 +319,7 @@ boot: bundle vphoned boot_binary_check
 	cd $(VM_DIR) && "$(CURDIR)/$(BUNDLE_BIN)" \
 		--config ./config.plist
 
-boot_less: bundle vphoned boot_binary_check_less
+boot_less: bundle boot_binary_check_less
 	cd $(VM_DIR) && "$(CURDIR)/$(BUNDLE_BIN)" \
 		--config ./config.plist \
 		--variant less \

--- a/scripts/setup_machine.sh
+++ b/scripts/setup_machine.sh
@@ -322,17 +322,22 @@ start_first_boot() {
   mkdir -p "$LOG_DIR"
   : > "$BOOT_LOG"
 
+  local target="boot"
+  if [ "$1" -eq 1 ]; then
+    target="boot_less"
+  fi
+
   BOOT_FIFO="$(mktemp -u "${TMPDIR:-/tmp}/vphone-first-boot.XXXXXX")"
   mkfifo "$BOOT_FIFO"
 
-  (make boot <"$BOOT_FIFO" >"$BOOT_LOG" 2>&1) &
+  (make "$target" <"$BOOT_FIFO" >"$BOOT_LOG" 2>&1) &
   BOOT_PID=$!
 
   exec {BOOT_FIFO_FD}>"$BOOT_FIFO"
 
   sleep 2
   if ! kill -0 "$BOOT_PID" 2>/dev/null; then
-    die "make boot exited early during first boot stage"
+    die "make $target exited early during first boot stage"
   fi
 }
 
@@ -801,7 +806,7 @@ main() {
       echo "[*] non-interactive (default): auto-starting first boot"
     fi
 
-    start_first_boot
+    start_first_boot "$LESS_MODE"
 
     if [[ "$NON_INTERACTIVE" -eq 0 ]]; then
       read -r "?[*] Press Enter once the VM is fully booted"

--- a/sources/FirmwarePatcher/Filesystem/CryptexFilesystemPatcher.swift
+++ b/sources/FirmwarePatcher/Filesystem/CryptexFilesystemPatcher.swift
@@ -84,6 +84,7 @@ public final class CryptexFilesystemPatcher: Patcher {
     public func apply() throws -> Int {
         print("Merging Filesystems")
         let (unencryptedImage, aeaImage) = try mergeFilesystems()
+        defer { try? FileManager.default.removeItem(at: unencryptedImage) }
         
         print("Creating Trustcache")
         let trustcachePath = try createTrustcache(filesystem: unencryptedImage)
@@ -114,10 +115,10 @@ public final class CryptexFilesystemPatcher: Patcher {
     func mergeFilesystems() throws -> (URL, URL) {
         let osPath = try getOSFilesystemPath()
         let osDmgPath = try decryptAeaFile(self.restoreDir.appending(path: osPath))
-        let tmpDir = try createTmpDir()
-        let newDmgPath = tmpDir.appending(path: "new-filesystem.dmg")
+        let newDmgPath = self.restoreDir.appending(path: "new-filesystem.dmg")
         
         print("- Converting OS image")
+        let tmpDir = try createTmpDir()
         let targetImagePath = tmpDir.appending(path: "disk.dmg")
         do {
             try convertToRawImage(input: osDmgPath, output: targetImagePath)
@@ -164,12 +165,12 @@ public final class CryptexFilesystemPatcher: Patcher {
         try convertToUDRWImage(input: targetImagePath, output: newDmgPath)
         let metadata = try getAeaMetadata(self.restoreDir.appending(path: osPath))
         let key = try getAeaKey(self.restoreDir.appending(path: osPath), metadata: metadata)
-        let finalFile = try encryptAeaFile(newDmgPath, key: key, metadata: metadata)
+        let finalFile = newDmgPath.appendingPathExtension("aea")
         let finalDestination = self.restoreDir.appending(path: finalFile.lastPathComponent)
         if FileManager.default.fileExists(atPath: finalDestination.path) {
             try FileManager.default.removeItem(at: finalDestination)
         }
-        try FileManager.default.moveItem(at: finalFile, to: finalDestination)
+        try encryptAeaFile(newDmgPath, output: finalFile, key: key, metadata: metadata)
         try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: finalDestination.path)
         return (newDmgPath, finalDestination)
     }
@@ -775,10 +776,9 @@ public final class CryptexFilesystemPatcher: Patcher {
         ]).trimmingCharacters(in: ["\n"])
     }
     
-    func encryptAeaFile(_ path: URL, key: String, metadata: [String: String]) throws -> URL {
-        let outputPath = path.appendingPathExtension("aea")
+    func encryptAeaFile(_ path: URL, output: URL, key: String, metadata: [String: String]) throws {
         var arguments = [
-            "encrypt", "-i", path.path, "-o", outputPath.path,
+            "encrypt", "-i", path.path, "-o", output.path,
             "-profile", "1", "-key-value", key,
         ]
         for (metaKey, metaValue) in metadata {
@@ -788,7 +788,6 @@ public final class CryptexFilesystemPatcher: Patcher {
             arguments.append(metaValue)
         }
         _ = try runProcess("/usr/bin/aea", arguments)
-        return outputPath
     }
     
     func decryptAeaFile(_ path: URL) throws -> URL {

--- a/sources/FirmwarePatcher/Pipeline/FirmwarePipeline.swift
+++ b/sources/FirmwarePatcher/Pipeline/FirmwarePipeline.swift
@@ -515,6 +515,8 @@ public final class FirmwarePipeline {
         if let kjb = patcher as? KernelJBPatcher { return kjb.buffer.data }
         if let kexp = patcher as? KernelEXPPatcher { return kexp.buffer.data }
         if let dt = patcher as? DeviceTreePatcher { return dt.patchedData }
+        if let fs = patcher as? CryptexFilesystemPatcher { return fs.patchedData }
+        if let mh = patcher as? ManifestHashPatcher { return mh.patchedData }
 
         // Fallback: apply records manually to a copy of the original data.
         var data = fallback


### PR DESCRIPTION
This PR contains a major and two minor fixes for the Patchless variant.
1. 7f1a210242c6f53b3c98acda08078a6793136086 removed saving the patched data for the Filesystem and Manifest patchers, which breaks the patchless variant. This PR re-adds it.
2. I've noticed that the tmp mount sometimes behaves weird for fs image resizing. This PR moves some image operations to the restore directory.
3. Building vphoned takes time and is not required for `boot_less`. This PR removes this Makefile dependency.

Feel free to squash the commits :)