### PR TITLE
Two host-side robustness fixes: amfidont lldb resolution + fw_prepare stale-cache invalidation

### DIFF
--- a/scripts/fw_prepare.sh
+++ b/scripts/fw_prepare.sh
@@ -356,31 +356,40 @@ fetch() {
     local src="$1" out="$2"
     if [[ -f "$out" ]]; then
         if is_local "$src"; then
-            echo "==> Skipping: '$out' already exists."
-            return
-        fi
-        # File exists — could be partial (interrupted) or complete.
-        # Attempt to resume; curl -C - is a no-op on a fully-downloaded file.
-        local local_size
-        local_size=$(wc -c < "$out" | tr -d ' ')
-        echo "==> Found existing ${out##*/} (${local_size} bytes), resuming ..."
-        local rc=0
-        download_file "$src" "$out" || rc=$?
-        if [[ $rc -eq 0 ]]; then
-            return
-        fi
-        # curl exit 22 = HTTP error; with -C - on a complete file the server
-        # returns 416 which --fail maps to exit 22.  Verify via content-length.
-        if [[ $rc -eq 22 ]]; then
-            local remote_size
-            remote_size=$(curl -sI --location "$src" | awk 'tolower($1)=="content-length:"{v=$2} END{print v}' | tr -d '\r')
-            if [[ -n "$remote_size" && "$local_size" -ge "$remote_size" ]]; then
-                echo "==> Already fully downloaded (${local_size} bytes)."
+            # Reuse the cached copy ONLY if it matches the source. A different
+            # local IPSW that happens to share the same basename (e.g. two
+            # cloudOS.ipsw files) must not silently reuse a stale copy.
+            if [[ -f "$src" ]] && \
+               [[ "$(wc -c <"$src" | tr -d ' ')" == "$(wc -c <"$out" | tr -d ' ')" ]]; then
+                echo "==> Skipping: '$out' already exists (matches source)."
                 return
             fi
+            echo "==> Cached '${out##*/}' differs from source — replacing ..."
+            rm -f "$out"
+        else
+            # Remote source, file exists — could be partial or complete.
+            # Attempt to resume; curl -C - is a no-op on a fully-downloaded file.
+            local local_size
+            local_size=$(wc -c < "$out" | tr -d ' ')
+            echo "==> Found existing ${out##*/} (${local_size} bytes), resuming ..."
+            local rc=0
+            download_file "$src" "$out" || rc=$?
+            if [[ $rc -eq 0 ]]; then
+                return
+            fi
+            # curl exit 22 = HTTP error; with -C - on a complete file the server
+            # returns 416 which --fail maps to exit 22.  Verify via content-length.
+            if [[ $rc -eq 22 ]]; then
+                local remote_size
+                remote_size=$(curl -sI --location "$src" | awk 'tolower($1)=="content-length:"{v=$2} END{print v}' | tr -d '\r')
+                if [[ -n "$remote_size" && "$local_size" -ge "$remote_size" ]]; then
+                    echo "==> Already fully downloaded (${local_size} bytes)."
+                    return
+                fi
+            fi
+            echo "==> Resume failed; retrying full download ..."
+            rm -f "$out"
         fi
-        echo "==> Resume failed; retrying full download ..."
-        rm -f "$out"
     fi
     if is_local "$src"; then
         [[ -f "$src" ]] || die "Local IPSW not found: $src"
@@ -397,7 +406,10 @@ fetch() {
 
 extract() {
     local zip="$1" cache="$2" out="$3"
-    if [[ -d "$cache" && -n "$(ls -A "$cache" 2>/dev/null)" ]]; then
+    # Reuse the extraction only if it's non-empty AND not older than the source
+    # zip. fetch() re-copies a changed source (fresh mtime), so a stale cache is
+    # correctly invalidated here.
+    if [[ -d "$cache" && -n "$(ls -A "$cache" 2>/dev/null)" && ! "$zip" -nt "$cache" ]]; then
         echo "==> Cached: ${cache##*/}"
     else
         rm -rf "$cache"

--- a/scripts/start_amfidont_for_vphone.sh
+++ b/scripts/start_amfidont_for_vphone.sh
@@ -17,9 +17,18 @@ if ! command -v amfidont &>/dev/null; then
   exit 1
 fi
 
-sudo xcrun amfidont daemon \
+# amfidont drives LLDB's Python bindings and must use *Xcode's* lldb (which
+# matches its Xcode python3 runtime). If a Homebrew LLVM lldb is first on PATH it
+# shadows Xcode's and ships incompatible bindings (e.g. Python 3.14 vs 3.9),
+# producing a "_lldb did not return an extension module" failure. Force the
+# Xcode toolchain so the `lldb -P` amfidont runs internally resolves correctly.
+XCODE_BIN="$(xcode-select -p 2>/dev/null)/usr/bin"
+AMFIDONT_BIN="$(command -v amfidont)"
+LOG=/tmp/amfidont-vphone.log
+
+sudo env PATH="$XCODE_BIN:/usr/bin:/bin" "$AMFIDONT_BIN" daemon \
     --path "$PROJECT_ROOT" \
     --spoof-apple \
-    >/dev/null 2>&1
+    >"$LOG" 2>&1
 
-echo "amfidont started"
+echo "amfidont started (log: $LOG)"


### PR DESCRIPTION
Two small, independent host-side robustness fixes discovered while running the
provisioning pipeline on a fresh macOS host. Neither touches the VM, patcher, or
firmware logic — both are in helper shell scripts.

### 1. `start_amfidont_for_vphone.sh`: force Xcode's lldb

`amfidont` drives LLDB's Python bindings and must use **Xcode's** `lldb` (which
matches its Xcode `python3` runtime). On a host that also has a Homebrew LLVM
`lldb` earlier on `PATH`, that one shadows Xcode's and ships incompatible
bindings (e.g. Python 3.14 vs 3.9), so the daemon dies at startup with:

```
_lldb did not return an extension module
```

…and then signed vphone-cli launches get SIGKILL'd (exit 137) because the
AMFI-bypass daemon never came up. Fix: pin the Xcode toolchain on `PATH` for the
`amfidont` invocation so its internal `lldb -P` resolves to Xcode's lldb
regardless of what else is installed.

### 2. `fw_prepare.sh`: invalidate stale IPSW cache when the source changes

`fw_prepare` caches downloaded/copied IPSWs under `ipsws/<basename>`. If you
reuse a basename (e.g. always uploading `cloudOS.ipsw`) but change the actual
file, the old cached copy — and its already-extracted directory — were reused,
so the build silently ran against the **previous** firmware. In practice this
surfaced as:

```
KeyError: 'No release identity for DeviceClass=vphone600ap'
```

when a newer cloudOS.ipsw (that *does* contain `vphone600ap`) was uploaded but a
stale extract without it was reused. Fix: for local sources, only reuse the
cached IPSW when its byte size matches the source (else replace it), and only
reuse the extracted dir when the zip isn't newer than the cache.

---

Both are opt-in-free and don't change behavior on hosts that were already
working. Happy to split into two PRs if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
