### PR TITLE
ci: build the portable .app in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,10 @@
 name: release
 
-# Build the signed vphone-cli.app and attach it to a published GitHub Release.
-# Signing is ad-hoc (codesign --sign -) with sources/vphone.entitlements, exactly
-# like a local `make bundle` — no Developer ID certificate or secrets required.
+# Build the portable, signed vphone-cli.app and attach it to a published
+# GitHub Release. Uses ./scripts/build.sh (the canonical build) so the .app
+# ships self-contained — bundled scripts/patchers/resources/requirements.txt/
+# vphoned/.tools — not the lean `make bundle` output. Signing is ad-hoc
+# (codesign --sign -) with sources/vphone.entitlements; no secrets required.
 
 on:
   release:
@@ -18,35 +20,60 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Init build submodules
-        # --recursive: libcapstone-spm builds capstone from its own nested
-        # Vendor/capstone submodule. Scoped to these paths, so the large
-        # scripts/resources storage submodule is still skipped.
+      - name: Init submodules
+        # vendor/* (--recursive: libcapstone-spm builds capstone from its own
+        # nested submodule) for the Swift build; scripts/resources is the CFW
+        # asset storage that build.sh bundles into the .app; scripts/repos/*
+        # provide the trustcache/insert_dylib tool sources.
         run: |
           git submodule update --init --recursive --depth 1 \
             vendor/swift-argument-parser \
             vendor/Dynamic \
             vendor/libcapstone-spm \
             vendor/libimg4-spm \
-            vendor/MachOKit
+            vendor/MachOKit \
+            scripts/resources \
+            scripts/repos/trustcache \
+            scripts/repos/insert_dylib
 
       - name: Toolchain versions
         run: |
           swift --version
           xcodebuild -version
 
-      - name: Install ldid
-        run: brew install ldid-procursus
+      - name: Install build deps
+        run: brew install ldid-procursus openssl@3
 
-      - name: Build and bundle
-        run: make bundle
-
-      - name: Verify entitlements
+      - name: Build .tools/bin/{trustcache,insert_dylib}
+        # build.sh bundles these runtime tools into the .app and errors if
+        # absent. Mirrors scripts/setup_tools.sh steps [2/4] and [3/4]; its
+        # venv ([4/4]) and sshpass ([1/4]) steps aren't needed to build.
         run: |
+          set -euo pipefail
+          mkdir -p .tools/bin
+          openssl_prefix="$(brew --prefix openssl@3)"
+          make -C scripts/repos/trustcache \
+            OPENSSL=1 \
+            CFLAGS="-I${openssl_prefix}/include -DOPENSSL -w" \
+            LDFLAGS="-L${openssl_prefix}/lib" \
+            -j"$(sysctl -n hw.logicalcpu)"
+          cp scripts/repos/trustcache/trustcache .tools/bin/trustcache
+          clang -o .tools/bin/insert_dylib \
+            scripts/repos/insert_dylib/insert_dylib/main.c -framework Security -O2
+
+      - name: Build and bundle (portable .app)
+        run: ./scripts/build.sh
+
+      - name: Verify the bundle is portable-complete and entitled
+        run: |
+          set -euo pipefail
+          res=.build/vphone-cli.app/Contents/Resources
+          for p in scripts/fw_prepare.sh scripts/patchers/cfw.py scripts/resources \
+                   requirements.txt vphoned.signed .tools/bin/trustcache .tools/bin/insert_dylib; do
+            [ -e "$res/$p" ] || { echo "::error::bundle is missing $p — not portable"; exit 1; }
+          done
           bin=.build/vphone-cli.app/Contents/MacOS/vphone-cli
-          ents=$(codesign -d --entitlements - "$bin" 2>&1)
-          echo "$ents"
-          echo "$ents" | grep -q 'com.apple.private.virtualization' \
+          codesign -d --entitlements - "$bin" 2>&1 | grep -q 'com.apple.private.virtualization' \
             || { echo "::error::required virtualization entitlement missing from signed app"; exit 1; }
 
       - name: Package app


### PR DESCRIPTION
## Summary

The release workflow built the app with `make bundle`, which produces a **lean** `.app` (binary + `ldid` + `signcert` + icon only). It never ran the mini-repo bundling and deliberately skipped the `scripts/resources` submodule, so published release assets were **not self-contained** — a copied or `brew install`-ed app could run `--help` but would fail on `fw prepare` / `fw patch` / `restore` / `cfw install` (they need the bundled scripts, patchers, resources, `vphoned`, and `.tools/bin`).

## Changes

- Switch the release job to **`./scripts/build.sh`** (the canonical portable build: `swift build` → sign → bundle the full mini-repo + `requirements.txt` + cross-compiled `vphoned` → re-sign).
- Also init the `scripts/resources` storage submodule and the `scripts/repos/{trustcache,insert_dylib}` tool sources.
- Build `.tools/bin/{trustcache,insert_dylib}` inline (mirrors `setup_tools.sh` steps 2–3; its venv + `sshpass` steps aren't needed to build and are slow/fragile on a runner).
- Add a guard step that **fails the job** if the bundle is missing any runtime asset (`scripts/`, `patchers/cfw.py`, `resources`, `requirements.txt`, `vphoned.signed`, `.tools/bin/*`) or the `com.apple.private.virtualization` entitlement — so this regression can't ship again.

## Why

Enables distributing a working, self-contained `.app` via GitHub Releases (and therefore Homebrew): `brew install` copies get the full create/restore/patch pipeline, not just `--help`.

## Testing / notes

- Workflow YAML validated; `scripts/build.sh` is `#!/bin/zsh` + executable, so `./scripts/build.sh` runs on the runner.
- The workflow triggers on `release: published`. To verify: cut a new release (e.g. `1.0.1`) and confirm the uploaded zip contains `vphone-cli.app/Contents/Resources/{scripts,requirements.txt,vphoned.signed,.tools/bin}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
