### PR TITLE
fix: run the CFW-install sudo as a foreground terminal job

### DIFF
--- a/sources/VPhoneCore/VPhoneProcessRunner.swift
+++ b/sources/VPhoneCore/VPhoneProcessRunner.swift
@@ -108,4 +108,63 @@ public enum VPhoneProcessRunner {
         process.waitUntilExit()
         return process.terminationStatus
     }
+
+    /// Run `executable args` as a controlling-terminal FOREGROUND job.
+    ///
+    /// Foundation spawns children in a new process group, which leaves them in
+    /// the *background* of the terminal — an interactive program they run (e.g.
+    /// `sudo`) then can't disable echo or read the tty (the password shows and
+    /// isn't delivered). This hands the terminal to the child's group via
+    /// `tcsetpgrp` for the duration, so sudo owns the tty and reads the password
+    /// directly; our process never sees it. Our foreground group is restored on
+    /// return. Falls back to a plain inherited run when there is no tty.
+    public static func runForeground(
+        _ executable: URL,
+        _ args: [String],
+        cwd: URL? = nil,
+        env: [String: String]? = nil,
+        echo: Bool = true
+    ) throws -> Int32 {
+        let process = Process()
+        process.executableURL = executable
+        process.arguments = args
+        if let cwd { process.currentDirectoryURL = cwd }
+        if let env { process.environment = env }
+        // When echo is false, suppress the child's normal output — but it still
+        // becomes the terminal's foreground group below, so an interactive sudo
+        // it runs still prompts/reads via /dev/tty (independent of stdout/stderr).
+        if !echo {
+            let devNull = FileHandle.nullDevice
+            process.standardOutput = devNull
+            process.standardError = devNull
+        }
+
+        var ttyFD = FileHandle.standardInput.fileDescriptor
+        var openedTTY = false
+        if isatty(ttyFD) == 0 {
+            let fd = open("/dev/tty", O_RDWR)
+            guard fd >= 0 else {
+                try process.run(); process.waitUntilExit(); return process.terminationStatus
+            }
+            ttyFD = fd
+            openedTTY = true
+        }
+
+        let savedFg = tcgetpgrp(ttyFD)
+        // tcsetpgrp from a background group would raise SIGTTOU/SIGTTIN (default:
+        // stop). Ignore them while we juggle the foreground group.
+        let prevTTOU = signal(SIGTTOU, SIG_IGN)
+        let prevTTIN = signal(SIGTTIN, SIG_IGN)
+        defer {
+            signal(SIGTTOU, prevTTOU)
+            signal(SIGTTIN, prevTTIN)
+            if openedTTY { close(ttyFD) }
+        }
+
+        try process.run()
+        _ = tcsetpgrp(ttyFD, process.processIdentifier)   // hand the tty to the child
+        process.waitUntilExit()
+        if savedFg > 0 { _ = tcsetpgrp(ttyFD, savedFg) }  // take it back
+        return process.terminationStatus
+    }
 }

--- a/sources/vphone-cli/VPhoneCreateOrchestrator.swift
+++ b/sources/vphone-cli/VPhoneCreateOrchestrator.swift
@@ -20,6 +20,7 @@ private enum VPhoneCreateError: Error, CustomStringConvertible {
     case restoreGetSHSHFailed(Int32)
     case restoreUpdateFailed(Int32)
     case cfwInstallFailed(Int32)
+    case sudoPasswordRequired
     case firstBootPanic
     case firstBootExitedBeforePrompt(Int32)
     case bootAnalysisPanic
@@ -53,6 +54,9 @@ private enum VPhoneCreateError: Error, CustomStringConvertible {
             "restore-update failed (exit \(code))"
         case let .cfwInstallFailed(code):
             "CFW install failed (exit \(code))"
+        case .sudoPasswordRequired:
+            "CFW install needs root but no sudo password is available — pass --sudo-password "
+                + "or run vm create in an interactive terminal"
         case .firstBootPanic:
             "first boot panicked before command injection"
         case let .firstBootExitedBeforePrompt(code):
@@ -161,16 +165,30 @@ public struct VPhoneCreateOrchestrator {
             throw VPhoneLibraryError.alreadyExists(name: options.name)
         }
 
-        // setup_sudo_noninteractive: preload an askpass helper so CFW install's
-        // internal `sudo -A` re-exec can run unattended.
+        // CFW install re-execs under sudo (host disk mount: mount_apfs + chown
+        // 0:0 are root-only). With --sudo-password we feed sudo non-interactively
+        // via the askpass helper. Otherwise sudo prompts on the terminal itself —
+        // the CFW-install step runs as a foreground job (runForeground) so sudo's
+        // process group owns the tty and reads the password directly; our code
+        // never sees it. `less` runs the whole create as root, so needs no password.
         var sudoEnvExtras: [String: String] = [:]
         var askpassScript: URL?
         defer { if let askpassScript { try? FileManager.default.removeItem(at: askpassScript) } }
-        if let password = options.sudoPassword, !password.isEmpty {
-            let script = try makeSudoAskpassScript(password: password)
-            askpassScript = script
-            sudoEnvExtras = ["SUDO_ASKPASS": script.path, "SUDO_PASSWORD": password]
-            preloadSudoCredential(env: sudoEnvExtras, verbosity: v)
+        if !isLess {
+            if let password = options.sudoPassword, !password.isEmpty {
+                let script = try makeSudoAskpassScript()
+                askpassScript = script
+                sudoEnvExtras = ["SUDO_ASKPASS": script.path, "SUDO_PASSWORD": password]
+                if preloadSudoCredential(env: sudoEnvExtras, verbosity: v) {
+                    print("[+] sudo credential preloaded via --sudo-password")
+                } else {
+                    print("[!] --sudo-password failed validation; will still try at CFW-install time")
+                }
+            } else if isatty(FileHandle.standardInput.fileDescriptor) == 0 {
+                // No password and no terminal for sudo to prompt on — fail before
+                // the long download/restore, not at the eventual sudo prompt.
+                throw VPhoneCreateError.sudoPasswordRequired
+            }
         }
 
         print("\n=== vm new ===")
@@ -247,7 +265,9 @@ public struct VPhoneCreateOrchestrator {
 
     // MARK: - sudo askpass
 
-    private func makeSudoAskpassScript(password: String) throws -> URL {
+    /// Askpass helper: emits `$SUDO_PASSWORD` (set per-invocation in the env).
+    /// The password is never written into the script itself.
+    private func makeSudoAskpassScript() throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("vphone-sudo-askpass-\(UUID().uuidString)")
         let script = "#!/bin/sh\nprintf '%s\\n' \"${SUDO_PASSWORD:-}\"\n"
@@ -256,16 +276,15 @@ public struct VPhoneCreateOrchestrator {
         return url
     }
 
-    private func preloadSudoCredential(env extras: [String: String], verbosity v: VPhoneVerbosity) {
+    /// Validate a sudo credential non-interactively via the askpass env
+    /// (`sudo -A -v`). Returns whether it succeeded.
+    private func preloadSudoCredential(env extras: [String: String], verbosity v: VPhoneVerbosity) -> Bool {
         var env = ProcessInfo.processInfo.environment
         for (key, value) in extras { env[key] = value }
         trace("spawn /usr/bin/sudo -A -v (env keys added: \(extras.keys.sorted().joined(separator: ", ")))", v)
-        let result = try? VPhoneProcessRunner.runCapturing(URL(fileURLWithPath: "/usr/bin/sudo"), ["-A", "-v"], env: env)
-        if result?.succeeded == true {
-            print("[+] sudo credential preloaded via SUDO_PASSWORD")
-        } else {
-            print("[!] SUDO_PASSWORD provided but sudo -A validation failed; continuing without preload")
-        }
+        let result = try? VPhoneProcessRunner.runCapturing(
+            URL(fileURLWithPath: "/usr/bin/sudo"), ["-A", "-v"], env: env)
+        return result?.succeeded == true
     }
 
     // MARK: - fw prepare / fw patch
@@ -437,8 +456,20 @@ public struct VPhoneCreateOrchestrator {
         let args = [resources.cfwInstallHostScript.path, "--variant", options.variant, bundleURL.path]
         let envKeys = (["VPHONE_PYTHON", "IPSW_DIR", "VPHONE_SEAL_DIR"] + sudoEnvExtras.keys.sorted()).joined(separator: ", ")
         trace("spawn /bin/zsh \(args.joined(separator: " ")) (env keys: \(envKeys))", v)
-        let code = try VPhoneProcessRunner.runStreaming(
-            URL(fileURLWithPath: "/bin/zsh"), args, env: env, echo: v.showsToolDetail)
+        // With an askpass credential sudo is non-interactive → honor verbosity.
+        // Without one, sudo must prompt on the terminal → run as a foreground job
+        // so its process group owns the tty (see runForeground).
+        let code: Int32
+        if sudoEnvExtras["SUDO_ASKPASS"] != nil {
+            code = try VPhoneProcessRunner.runStreaming(
+                URL(fileURLWithPath: "/bin/zsh"), args, env: env, echo: v.showsToolDetail)
+        } else {
+            print("[*] CFW install needs root — sudo will prompt for your macOS password.")
+            // Foreground so sudo can own the tty; echo honors verbosity (quiet
+            // suppresses the install's own output, sudo's /dev/tty prompt stays).
+            code = try VPhoneProcessRunner.runForeground(
+                URL(fileURLWithPath: "/bin/zsh"), args, env: env, echo: v.showsToolDetail)
+        }
         guard code == 0 else { throw VPhoneCreateError.cfwInstallFailed(code) }
         print("[+] CFW installed (\(options.variant)).")
     }

--- a/tests/VPhoneCoreTests/LibraryTests.swift
+++ b/tests/VPhoneCoreTests/LibraryTests.swift
@@ -2,6 +2,10 @@
 import Foundation
 import Testing
 
+// Serialized: defaultRootHonorsEnvOverride / defaultRootIsShellSafe mutate the
+// process-global VPHONE_LIBRARY_ROOT; run in parallel they race (a set/unset
+// from one can land inside the other's assertion).
+@Suite(.serialized)
 struct LibraryTests {
     private func makeRoot() throws -> URL {
         let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)


### PR DESCRIPTION
## Summary

A `vm create` without `--sudo-password` couldn't accept the sudo password for the CFW host-mount install — the typed password was echoed (not hidden) and never delivered to sudo.

## Root cause

Foundation `Process` starts children in a **new process group**, so the `sudo` it spawns is a *background* member of the controlling terminal. From there sudo can't disable echo or read the tty. Verified: a `Process` child's pgid ≠ the parent's. No amount of stdio wiring fixes it.

## Fix

- New `VPhoneProcessRunner.runForeground`: hands the terminal to the child's process group via `tcsetpgrp` (ignoring `SIGTTOU`/`SIGTTIN` during the swap) for the duration, then restores ours. So `sudo` owns the tty and reads the password **directly** — vphone-cli never sees it.
- The CFW-install step uses it when no `--sudo-password` is given. Its `echo` flag honors verbosity: quiet suppresses the install's own output (stdout/stderr → `/dev/null`) while sudo's `/dev/tty` prompt still works.
- `--sudo-password` keeps the unattended askpass path; a non-interactive run with no password fails fast with a clear error.
- Serialize `LibraryTests`: its two `VPHONE_LIBRARY_ROOT` env tests mutate a process-global and raced under Swift Testing's parallelism (intermittent failures).

## Testing

- Verified under a PTY: without `tcsetpgrp` the child is background (the bug); with it, foreground; and `echo=false` hides the child's output while it stays foreground.
- A full `vm create --variant jb` run succeeds end-to-end: direct sudo prompt → CFW install → boot success.
- 79/79 VPhoneCore tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
