### PR TITLE
fix: preflight checks the running binary, not a dev .build path

### DIFF
--- a/scripts/boot_host_preflight.sh
+++ b/scripts/boot_host_preflight.sh
@@ -34,7 +34,11 @@ done
 
 cd "$PROJECT_ROOT"
 
-RELEASE_BIN="${PROJECT_ROOT}/.build/release/vphone-cli"
+# The caller (vphone-cli) passes VPHONE_CLI_BIN = the running binary, so we
+# check THAT — the bundled .app's Contents/MacOS/vphone-cli, not a dev
+# .build/release path that doesn't exist inside the bundle. Falls back to the
+# dev layout for standalone/`make` invocation.
+RELEASE_BIN="${VPHONE_CLI_BIN:-${PROJECT_ROOT}/.build/release/vphone-cli}"
 DEBUG_BIN="${PROJECT_ROOT}/.build/debug/vphone-cli"
 ENTITLEMENTS="${PROJECT_ROOT}/sources/vphone.entitlements"
 TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/vphone-preflight.XXXXXX")"

--- a/sources/vphone-cli/VPhoneVMLaunchCLI.swift
+++ b/sources/vphone-cli/VPhoneVMLaunchCLI.swift
@@ -25,25 +25,29 @@ struct VPhoneVMLaunchCommand: ParsableCommand {
         let resources = projectRoot.map { VPhoneResources(base: URL(fileURLWithPath: $0)) } ?? .resolve()
         let layout = VPhoneLaunchLayout(resources: resources)
 
-        // Host preflight — same gate make boot applies.
-        var preflightArgs = ["--assert-bootable"]
-        if variant == "less" { preflightArgs.append("--less") }
-        let pre = try VPhoneProcessRunner.runCapturing(
-            URL(fileURLWithPath: "/bin/zsh"), [layout.preflightScript.path] + preflightArgs,
-            cwd: resources.base)
-        if !pre.stdout.isEmpty { print(pre.stdout, terminator: "") }
-        guard pre.succeeded else {
-            FileHandle.standardError.write(Data(pre.stderr.utf8))
-            throw ExitCode(pre.exitCode == 0 ? 1 : pre.exitCode)
-        }
-
-        // A bundled .app is its own boot binary — self-spawn the running executable
-        // for both the GUI and --dfu (headless) boot paths.
+        // The running executable is BOTH what we boot from and what preflight
+        // should check — a bundled .app is its own boot binary.
         let bootBinary = URL(fileURLWithPath: CommandLine.arguments[0]).resolvingSymlinksInPath()
         guard FileManager.default.isExecutableFile(atPath: bootBinary.path) else {
             FileHandle.standardError.write(Data(
                 "error: \(bootBinary.path) not found — build it first (make build/bundle).\n".utf8))
             throw ExitCode(1)
+        }
+
+        // Host preflight — same gate make boot applies. Point it at THIS binary
+        // (VPHONE_CLI_BIN) so it checks the vphone-cli we're running, not a dev
+        // .build/release path that doesn't exist inside the bundled .app.
+        var preflightArgs = ["--assert-bootable"]
+        if variant == "less" { preflightArgs.append("--less") }
+        var preflightEnv = ProcessInfo.processInfo.environment
+        preflightEnv["VPHONE_CLI_BIN"] = bootBinary.path
+        let pre = try VPhoneProcessRunner.runCapturing(
+            URL(fileURLWithPath: "/bin/zsh"), [layout.preflightScript.path] + preflightArgs,
+            cwd: resources.base, env: preflightEnv)
+        if !pre.stdout.isEmpty { print(pre.stdout, terminator: "") }
+        guard pre.succeeded else {
+            FileHandle.standardError.write(Data(pre.stderr.utf8))
+            throw ExitCode(pre.exitCode == 0 ? 1 : pre.exitCode)
         }
 
         if !dfu && !noVphoned {


### PR DESCRIPTION
## Summary

`vm launch` from a bundled `.app` (brew-installed, or copied to `/Applications`) failed its host preflight with `missing release binary`, because the preflight checked a hardcoded dev path instead of the binary actually running.

## Root cause

`boot_host_preflight.sh` set `RELEASE_BIN="$PROJECT_ROOT/.build/release/vphone-cli"`. Inside the bundle `PROJECT_ROOT` resolves to `Contents/Resources`, so it looked for `Contents/Resources/.build/release/vphone-cli` — but the binary is at `Contents/MacOS/vphone-cli`. Under `--assert-bootable` the missing binary made the preflight exit non-zero, blocking launch.

## Fix

- `vm launch` passes the running executable (`CommandLine.arguments[0]`) to the preflight via a `VPHONE_CLI_BIN` env var.
- `boot_host_preflight.sh` uses `RELEASE_BIN="${VPHONE_CLI_BIN:-$PROJECT_ROOT/.build/release/vphone-cli}"` — it checks the vphone-cli we're running, and still falls back to the dev `.build/release` layout for standalone / `make` invocation.

## Testing

- With `VPHONE_CLI_BIN` set, the preflight reads the real binary's entitlements (incl. `com.apple.private.virtualization`), `release_help` exits 0, and `--assert-bootable` exits 0 (it failed before).
- `make build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
