### PR TITLE
Add vphone-amfidont helper to allowlist the .app through amfid

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -52,6 +52,10 @@ cp -f "sources/AppIcon.icns" "${BUNDLE}/Contents/Resources/AppIcon.icns"
 cp -f "scripts/vphoned/signcert.p12" "${BUNDLE}/Contents/Resources/signcert.p12"
 cp -f "$(command -v ldid)" "${BUNDLE}/Contents/MacOS/ldid"
 codesign --force --sign - "${BUNDLE}/Contents/MacOS/ldid"
+# vphone-amfidont helper (allows this .app through amfid). Bundled next to the
+# main binary so a Homebrew `binary` symlink can put it on PATH.
+cp -f "scripts/vphone-amfidont" "${BUNDLE}/Contents/MacOS/vphone-amfidont"
+chmod +x "${BUNDLE}/Contents/MacOS/vphone-amfidont"
 codesign --force --sign - --entitlements "$ENTITLEMENTS" "$BUNDLE_BIN"
 echo "  bundled → ${BUNDLE}"
 

--- a/scripts/vphone-amfidont
+++ b/scripts/vphone-amfidont
@@ -1,0 +1,43 @@
+#!/bin/zsh
+# vphone-amfidont — allow this vphone-cli.app through amfid via amfidont,
+# started in daemon mode with --spoof-apple. Automates the README "Option B"
+# step. amfidont: https://github.com/zqxwce/amfidont
+set -euo pipefail
+
+# The enclosing .app (this lives at vphone-cli.app/Contents/MacOS/vphone-amfidont;
+# `:A` resolves a Homebrew symlink back into the bundle).
+app="${0:A:h:h:h}"
+[[ "${app:e}" == app && -x "$app/Contents/MacOS/vphone-cli" ]] \
+  || { print -u2 "error: run vphone-amfidont from inside vphone-cli.app"; exit 1 }
+
+# Ensure amfidont is installed.
+if ! command -v amfidont >/dev/null; then
+  printf "amfidont is not installed. Install it via pip now? [y/N] "
+  read -r ans || ans=n
+  [[ "$ans" == [yY]* ]] || { print "Aborted."; exit 1 }
+  xcrun python3 -m pip install -U amfidont
+  command -v amfidont >/dev/null \
+    || { print -u2 "amfidont installed but not on PATH — open a new shell and retry."; exit 1 }
+fi
+# Absolute path: sudo's secure_path won't find a pip-user install by name.
+bin="$(command -v amfidont)"
+
+# Is amfidont already running? Only one can attach to amfid at a time. Check
+# cheaply without root first; its args (and /var/root config) need root, so
+# escalate to a single sudo ONLY when something is actually running.
+raw="$(ps -ax -o pid=,command= | grep '[a]mfidont' | grep -v vphone-amfidont | awk '{print $1}' || true)"
+if [[ -n "${raw//[[:space:]]/}" ]]; then
+  pids=(${(f)raw})
+  print "amfidont is already running — checking coverage (needs sudo)…"
+  info="$(sudo sh -c "ps -o command= -p ${(j:,:)pids} 2>/dev/null; cat /var/root/.amfidont/paths 2>/dev/null" || true)"
+  info+=$'\n'"$(cat ~/.amfidont/paths 2>/dev/null || true)"
+  # Covered if this .app's path is allowed, or if it's running with --allow-all.
+  if print -r -- "$info" | grep -Fq -- "$app" || print -r -- "$info" | grep -Fq -- "--allow-all"; then
+    print "amfidont is already running and allows this .app — nothing to do."
+    exit 0
+  fi
+  print -u2 "amfidont is already running but does NOT allow this .app. Stop it, then re-run vphone-amfidont."
+  exit 1
+fi
+
+exec sudo "$bin" daemon --spoof-apple --path "$app"


### PR DESCRIPTION
## What

Adds a small bundled tool, **`vphone-amfidont`**, that automates the manual "Option B" allowlist step from the README — allowing the unsigned `vphone-cli.app` through `amfid` via [amfidont](https://github.com/zqxwce/amfidont) — so users on the `csrutil enable --without debug` path can run it with one command instead of hand-writing the `amfidont` invocation.

## Behavior

- Resolves the enclosing `vphone-cli.app` (`${0:A:h:h:h}`; `:A` follows a Homebrew symlink back into the bundle).
- Ensures `amfidont` is installed, offering `xcrun python3 -m pip install -U amfidont` if it isn't.
- Checks (without root) whether an `amfidont` is already running — only one can attach to `amfid` at a time. If so, it escalates to a **single** `sudo` to read the running process's args and the `/var/root` config, reports whether this `.app` is already covered (an allowed path or `--allow-all`), and exits.
- Otherwise starts `amfidont daemon --spoof-apple --path <app>`, resolving `amfidont`'s absolute path first so a pip-user install that isn't on root's `secure_path` is still found under `sudo`.

## Build

`build.sh` bundles the script into `Contents/MacOS/` next to `vphone-cli`/`ldid`, so it ships in the formal `.app` build.

> Note: to expose `vphone-amfidont` on `PATH` for Homebrew installs, the cask needs a second `binary` stanza pointing at `…/Contents/MacOS/vphone-amfidont` (separate tap repo; not part of this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)