### PR TITLE
Fix release build: bundle vphone-amfidont in Resources, not MacOS

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -52,10 +52,6 @@ cp -f "sources/AppIcon.icns" "${BUNDLE}/Contents/Resources/AppIcon.icns"
 cp -f "scripts/vphoned/signcert.p12" "${BUNDLE}/Contents/Resources/signcert.p12"
 cp -f "$(command -v ldid)" "${BUNDLE}/Contents/MacOS/ldid"
 codesign --force --sign - "${BUNDLE}/Contents/MacOS/ldid"
-# vphone-amfidont helper (allows this .app through amfid). Bundled next to the
-# main binary so a Homebrew `binary` symlink can put it on PATH.
-cp -f "scripts/vphone-amfidont" "${BUNDLE}/Contents/MacOS/vphone-amfidont"
-chmod +x "${BUNDLE}/Contents/MacOS/vphone-amfidont"
 codesign --force --sign - --entitlements "$ENTITLEMENTS" "$BUNDLE_BIN"
 echo "  bundled → ${BUNDLE}"
 
@@ -103,7 +99,12 @@ cp -f requirements.txt "${RES}/requirements.txt"
 # = the Tested-Environments table fw_prepare.sh reads to label Supported firmwares.
 cp -f debs.list "${RES}/debs.list"
 cp -f README.md "${RES}/README.md"
-echo "  bundled: scripts/ (patchers+resources), tools/, .tools/bin/{trustcache,insert_dylib}, vphoned.signed, requirements.txt, debs.list, README.md"
+# vphone-amfidont helper (allows this .app through amfid). Kept in Resources —
+# NOT MacOS — so bundle signing doesn't reject it as unsigned nested code; a
+# Homebrew `binary` symlink exposes it on PATH.
+cp -f scripts/vphone-amfidont "${RES}/vphone-amfidont"
+chmod +x "${RES}/vphone-amfidont"
+echo "  bundled: scripts/ (patchers+resources), tools/, .tools/bin/{trustcache,insert_dylib}, vphoned.signed, requirements.txt, debs.list, README.md, vphone-amfidont"
 
 # Re-sign: codesign seals Contents/Resources at sign time, so the earlier
 # bundle-step signature (made before these assets existed) is now stale —

--- a/scripts/vphone-amfidont
+++ b/scripts/vphone-amfidont
@@ -4,7 +4,7 @@
 # step. amfidont: https://github.com/zqxwce/amfidont
 set -euo pipefail
 
-# The enclosing .app (this lives at vphone-cli.app/Contents/MacOS/vphone-amfidont;
+# The enclosing .app (this lives at vphone-cli.app/Contents/Resources/vphone-amfidont;
 # `:A` resolves a Homebrew symlink back into the bundle).
 app="${0:A:h:h:h}"
 [[ "${app:e}" == app && -x "$app/Contents/MacOS/vphone-cli" ]] \


### PR DESCRIPTION
## Problem

The **v1.0.2** release build failed at the bundle `codesign` step:

```
.build/vphone-cli.app/Contents/MacOS/vphone-cli: code object is not signed at all
In subcomponent: .../Contents/MacOS/vphone-amfidont
```

`Contents/MacOS/` is the bundle's nested-code directory, so signing the main executable seals everything there — and rejected the `vphone-amfidont` **shell script** as unsigned nested code. (A script only receives a "generic" xattr signature, which wouldn't survive the release zip anyway.)

## Fix

Bundle the helper at `Contents/Resources/vphone-amfidont` instead, where it's sealed as an ordinary resource (content-hashed; survives zip). `Resources/` sits at the same depth under `Contents/` as `MacOS/`, so the script's `${0:A:h:h:h}` `.app` resolution is unchanged.

- `build.sh`: drop the `Contents/MacOS/` copy; copy the script into `Contents/Resources/` alongside the other bundled runtime assets.
- `vphone-amfidont`: comment-only update of its bundled location.

## Verification

Local `./scripts/build.sh` now completes: `resealed OK`, `MacOS/` contains only `vphone-cli` + `ldid`, `Resources/vphone-amfidont` present + executable, and `codesign --verify` passes.

## Follow-up (not in this PR)

The Homebrew cask's `binary` stanza should point at `…/Contents/Resources/vphone-amfidont` (was going to be `…/Contents/MacOS/…`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)