### PR TITLE
Reclaim intermediate build artifacts after use

### DIFF
--- a/scripts/cfw_install_host.sh
+++ b/scripts/cfw_install_host.sh
@@ -88,6 +88,11 @@ trap - EXIT
 echo "[*] flipping boot snapshot offline (com.apple.os.update -> live volume)..."
 "$PY" "$PROJ/tools/apfs_snap_rename.py" "$IMG"
 
+# Drop the extracted CFW input dirs (source .tar.zst re-extracts). VPHONE_KEEP_ARTIFACTS opts out.
+if [[ -z "${VPHONE_KEEP_ARTIFACTS:-}" ]]; then
+  rm -rf "${VM_DIR:?}/cfw_input" "${VM_DIR:?}/cfw_jb_input"
+fi
+
 # The whole install ran as root (owners-honored mounts / chown / cp). Hand the
 # host-side artifacts it created (vm/.vphoned.signed, vm/.cfw_temp, extracted
 # cfw_input/cfw_jb_input, the vphoned build) back to the invoking user, so the

--- a/scripts/fw_prepare.sh
+++ b/scripts/fw_prepare.sh
@@ -687,5 +687,13 @@ echo "==> Generating hybrid plists ..."
 echo "==> Cleaning up ..."
 rm -rf "$CLOUDOS_DIR"
 
+# Drop the extracted base-IPSW caches (kept .ipsw re-extracts). VPHONE_KEEP_ARTIFACTS opts out.
+if [[ -z "${VPHONE_KEEP_ARTIFACTS:-}" ]]; then
+    hybrid="$(cd "$IPHONE_DIR" && pwd -P)"
+    for cache in "$IPHONE_CACHE" "$CLOUDOS_CACHE"; do
+        [[ -d "$cache" && "$(cd "$cache" && pwd -P)" != "$hybrid" ]] && rm -rf "$cache"
+    done
+fi
+
 echo "==> Done. Restore directory ready: $IPHONE_DIR/"
 echo "    Run 'make fw_patch' to patch boot-chain components."

--- a/sources/VPhoneCore/VPhoneRestoreInfo.swift
+++ b/sources/VPhoneCore/VPhoneRestoreInfo.swift
@@ -57,6 +57,15 @@ public struct VPhoneRestoreInfo: Codable, Equatable, Sendable {
         try encoder.encode(self).write(to: Self.url(forBundle: bundle))
     }
 
+    /// Remove the `iPhone*_Restore/` tree from the bundle; returns its name, or
+    /// nil if absent. Record versions (`derive`) first — it reads this directory.
+    @discardableResult
+    public static func removeBuiltFirmware(fromBundle bundle: VPhoneBundle) throws -> String? {
+        guard let dir = findRestoreDirectory(inBundle: bundle) else { return nil }
+        try FileManager.default.removeItem(at: dir)
+        return dir.lastPathComponent
+    }
+
     // MARK: - Restore-directory reads
 
     static func findRestoreDirectory(inBundle bundle: VPhoneBundle) -> URL? {

--- a/sources/vphone-cli/VPhoneCreateOrchestrator.swift
+++ b/sources/vphone-cli/VPhoneCreateOrchestrator.swift
@@ -104,6 +104,7 @@ public struct VPhoneCreateOrchestrator {
         public var memoryMB: UInt64
         public var diskSizeGB: UInt64
         public var verbosity: VPhoneVerbosity
+        public var keepArtifacts: Bool
 
         public init(
             name: String,
@@ -117,7 +118,8 @@ public struct VPhoneCreateOrchestrator {
             cpuCount: UInt = 8,
             memoryMB: UInt64 = 8192,
             diskSizeGB: UInt64 = 64,
-            verbosity: VPhoneVerbosity = .quiet
+            verbosity: VPhoneVerbosity = .quiet,
+            keepArtifacts: Bool = false
         ) {
             self.name = name
             self.variant = variant
@@ -131,6 +133,7 @@ public struct VPhoneCreateOrchestrator {
             self.memoryMB = memoryMB
             self.diskSizeGB = diskSizeGB
             self.verbosity = verbosity
+            self.keepArtifacts = keepArtifacts
         }
     }
 
@@ -213,6 +216,13 @@ public struct VPhoneCreateOrchestrator {
             Thread.sleep(forTimeInterval: 5)
             print("\n=== CFW install (host-mount) ===")
             try runCFWInstall(options: options, bundleURL: bundleURL, sudoEnvExtras: sudoEnvExtras)
+        }
+
+        // CFW install is the last consumer of the built restore tree (it copies
+        // the SystemOS/AppOS cryptexes from it onto Disk.img); reclaim it now.
+        if !options.keepArtifacts, let bundle = try? VPhoneBundle.load(at: bundleURL),
+           let removed = try? VPhoneRestoreInfo.removeBuiltFirmware(fromBundle: bundle) {
+            print("[+] Removed built firmware \(removed)/ to save space (--keep-artifacts to keep)")
         }
 
         print("\n=== First boot ===")
@@ -301,6 +311,7 @@ public struct VPhoneCreateOrchestrator {
         env["IPSW_DIR"] = resources.ipswCacheDir.path
         env["VPHONE_SEAL_DIR"] = resources.sealVolumeCacheDir.path
         if isLess { env["VARIANT"] = "less" }
+        if options.keepArtifacts { env["VPHONE_KEEP_ARTIFACTS"] = "1" }
 
         trace("spawn /bin/bash \(resources.fwPrepareScript.path) (env keys: VPHONE_PYTHON, IPSW_DIR, VPHONE_SEAL_DIR)", v)
         let code = try VPhoneProcessRunner.runStreaming(
@@ -474,6 +485,7 @@ public struct VPhoneCreateOrchestrator {
         env["IPSW_DIR"] = resources.ipswCacheDir.path
         env["VPHONE_SEAL_DIR"] = resources.sealVolumeCacheDir.path
         env["VPHONE_DEBS_DIR"] = resources.debsCacheDir.path
+        if options.keepArtifacts { env["VPHONE_KEEP_ARTIFACTS"] = "1" }
         for (key, value) in sudoEnvExtras { env[key] = value }
 
         let args = [resources.cfwInstallHostScript.path, "--variant", options.variant, bundleURL.path]

--- a/sources/vphone-cli/VPhoneRestoreCLI.swift
+++ b/sources/vphone-cli/VPhoneRestoreCLI.swift
@@ -104,6 +104,7 @@ struct VPhoneCFWInstallCommand: ParsableCommand {
     @Option(name: [.customShort("V"), .long], help: "variant: regular | dev | jb | exp") var variant: String = "exp"
     @Option(name: [.customShort("b"), .long], help: "(exp only) rewrite ProductBuildVersion to this build id") var spoofBuild: String?
     @Flag(name: .customLong("force-dsc-maxslide"), help: "Zero the dyld cache maxSlide on non-27 bases (opt-in DSC-map fit)") var forceDSCMaxSlide = false
+    @Flag(name: .customLong("keep-artifacts"), help: "Keep the extracted CFW input dirs (cfw_input/, cfw_jb_input/) after install (default: removed to save space)") var keepArtifacts = false
     @Option(name: .shortAndLong, help: "Resource base override (default: inferred from the running binary path)")
     var projectRoot: String?
     @Flag(name: .customShort("v"), help: "Increase verbosity: -v tool detail, -vv guest serial, -vvv internal trace")
@@ -121,6 +122,7 @@ struct VPhoneCFWInstallCommand: ParsableCommand {
         var env = ProcessInfo.processInfo.environment
         if let spoofBuild { env["SPOOF_BUILD"] = spoofBuild }
         if forceDSCMaxSlide { env["FORCE_DSC_MAXSLIDE"] = "1" }
+        if keepArtifacts { env["VPHONE_KEEP_ARTIFACTS"] = "1" }
 
         // Same redirect as `fw prepare`: VPHONE_PYTHON/IPSW_DIR/VPHONE_SEAL_DIR are
         // exported for the bundled scripts (cfw_install_host.sh's PY/P lines honor
@@ -140,6 +142,9 @@ struct VPhoneCFWInstallCommand: ParsableCommand {
         }
         let code = try VPhoneProcessRunner.runStreaming(
             URL(fileURLWithPath: "/bin/zsh"), args, env: env, echo: v.showsToolDetail)
+        if code == 0, !keepArtifacts, let removed = try? VPhoneRestoreInfo.removeBuiltFirmware(fromBundle: bundle) {
+            print("[cfw] removed built firmware \(removed)/ to save space (--keep-artifacts to keep)")
+        }
         throw ExitCode(code)
     }
 }

--- a/sources/vphone-cli/VPhoneVMCreateCLI.swift
+++ b/sources/vphone-cli/VPhoneVMCreateCLI.swift
@@ -21,6 +21,8 @@ struct VPhoneVMCreateCommand: ParsableCommand {
     @Option(name: [.customShort("b"), .long], help: "(exp only) rewrite ProductBuildVersion to this build id") var spoofBuild: String?
     @Flag(name: .customLong("force-dsc-maxslide"), help: "Zero the dyld cache maxSlide on non-27 bases (opt-in DSC-map fit)") var forceDSCMaxSlide = false
     @Flag(help: "Prompt at first-boot stages instead of running non-interactively") var interactive = false
+    @Flag(name: .customLong("keep-artifacts"), help: "Keep intermediate build artifacts (built restore firmware, extracted base-IPSW caches, extracted CFW input dirs) instead of removing them after use. Source archives (.ipsw / .tar.zst) are always kept.")
+    var keepArtifacts = false
     @Option(name: .shortAndLong, help: "Resource base override (default: inferred from the running binary path)")
     var projectRoot: String?
     @Flag(name: .customShort("v"), help: "Increase verbosity: -v tool detail, -vv guest serial, -vvv internal trace")
@@ -37,6 +39,7 @@ struct VPhoneVMCreateCommand: ParsableCommand {
             name: name, variant: variant,
             iphoneSource: sources.iphoneSource, cloudosSource: sources.cloudosSource,
             sudoPassword: sudoPassword, spoofBuild: spoofBuild, forceDSCMaxSlide: forceDSCMaxSlide,
-            interactive: interactive, verbosity: VPhoneVerbosity(count: verboseCount)))
+            interactive: interactive, verbosity: VPhoneVerbosity(count: verboseCount),
+            keepArtifacts: keepArtifacts))
     }
 }


### PR DESCRIPTION
## What

Frees disk by deleting the large, regenerable build intermediates once their consumers finish. Source archives are always kept, so nothing needs re-downloading.

- **Built restore firmware** (`iPhone*_Restore/`): removed after CFW install — its true last consumer (it copies the SystemOS/AppOS cryptexes out of the tree onto `Disk.img`).
- **Extracted base-IPSW dirs** (iOS + cloudOS): removed at the end of `fw prepare`; the downloaded `.ipsw` files are kept, so a re-run re-extracts with no re-download.
- **Extracted CFW input dirs** (`cfw_input/`, `cfw_jb_input/`): removed after `cfw install`; the `resources/*.tar.zst` archives are kept.

## Opt out

`--keep-artifacts` on `vm create` and `cfw install` keeps everything. It threads `VPHONE_KEEP_ARTIFACTS` through to `fw_prepare.sh` and `cfw_install_host.sh`.

## Notes

- The restore tree is removed **after** CFW install (not after restore): the CFW variant installers call `find_restore_dir()` and copy the cryptex DMGs from it, so restore is not the last consumer.
- The `fw_prepare` cache removal guards against deleting the active hybrid restore tree in the edge case where `IPSW_DIR` resolves to the working directory.

## Test plan

- `make build` clean + signed.
- `--keep-artifacts` present on `vm create` / `cfw install`, absent from `restore` (which no longer touches the tree).
- `bash -n scripts/fw_prepare.sh`, `zsh -n scripts/cfw_install_host.sh` pass.
- `fw_prepare` guard verified in isolation across normal / `IPSW_DIR==CWD` collision / keep-flag cases (caches removed, active tree preserved, keep-flag respected).
