### PR TITLE
vphone-cli: Add network to `vm info`/`vm list` JSON

### DIFF
--- a/sources/VPhoneCore/VPhoneBundleReport.swift
+++ b/sources/VPhoneCore/VPhoneBundleReport.swift
@@ -5,6 +5,7 @@ public struct VPhoneBundleReport: Codable, Equatable, Sendable {
     public let cpuCount: Int
     public let memoryMB: Int
     public let diskSizeBytes: Int64
+    public let network: VPhoneVirtualMachineManifest.NetworkConfig
     public let restoreInfo: VPhoneRestoreInfo?
     public let udid: String?
 
@@ -13,6 +14,7 @@ public struct VPhoneBundleReport: Codable, Equatable, Sendable {
         self.cpuCount = Int(bundle.manifest.cpuCount)
         self.memoryMB = Int(bundle.manifest.memorySize / (1024 * 1024))
         self.diskSizeBytes = bundle.diskSizeBytes
+        self.network = bundle.manifest.networkConfig
         self.restoreInfo = VPhoneRestoreInfo.load(fromBundle: bundle)
         self.udid = VPhoneRestoreOps.resolveUDID(bundle: bundle)
     }

--- a/sources/VPhoneCore/VPhoneVirtualMachineManifest.swift
+++ b/sources/VPhoneCore/VPhoneVirtualMachineManifest.swift
@@ -102,7 +102,7 @@ public struct VPhoneVirtualMachineManifest: Codable, Sendable {
         }
     }
 
-    public struct NetworkConfig: Codable, Sendable {
+    public struct NetworkConfig: Codable, Equatable, Sendable {
         public let mode: NetworkMode
         public let macAddress: String
         /// Host interface identifier to bridge (bridged mode only); nil otherwise.

--- a/sources/vphone-cli/VPhoneVMCLI.swift
+++ b/sources/vphone-cli/VPhoneVMCLI.swift
@@ -90,7 +90,7 @@ struct VPhoneVMInfoCommand: ParsableCommand {
             print("cpu:   \(report.cpuCount)")
             print("mem:   \(report.memoryMB) MB")
             print("disk:  \(report.diskSizeBytes) bytes")
-            print("net:   \(describeNetwork(bundle.manifest.networkConfig))")
+            print("net:   \(describeNetwork(report.network))")
             if let udid = report.udid { print("udid:  \(udid)") }
             if let info = report.restoreInfo {
                 print("iOS:     \(info.ios.version) (\(info.ios.build))")

--- a/tests/VPhoneCoreTests/BundleReportTests.swift
+++ b/tests/VPhoneCoreTests/BundleReportTests.swift
@@ -13,6 +13,24 @@ struct BundleReportTests {
         #expect(report.name == "myvm")
         #expect(report.cpuCount == 6)
         #expect(report.memoryMB == 4096)
+        #expect(report.network.mode == .nat)
+    }
+
+    @Test func carriesNetworkConfig() throws {
+        let net = VPhoneVirtualMachineManifest.NetworkConfig(
+            mode: .bridged, macAddress: "00:11:22:33:44:55", bridgeInterface: "en0")
+        let manifest = VPhoneVirtualMachineManifest(
+            cpuCount: 2, memorySize: 2 * 1024 * 1024 * 1024,
+            networkConfig: net,
+            romImages: .init(avpBooter: "a", avpSEPBooter: "b"))
+        let report = VPhoneBundleReport(
+            bundle: VPhoneBundle(url: URL(fileURLWithPath: "/tmp/b"), manifest: manifest))
+        #expect(report.network.mode == .bridged)
+        #expect(report.network.bridgeInterface == "en0")
+
+        let back = try JSONDecoder().decode(
+            VPhoneBundleReport.self, from: try JSONEncoder().encode(report))
+        #expect(back.network == net)
     }
 
     @Test func encodesToJSON() throws {


### PR DESCRIPTION
## Problem

`vphone-cli vm info --json` (and `vm list --json`) omit the VM's network configuration. Both commands JSON-encode `VPhoneBundleReport`, which had no network field, while only the human-readable output prints `net:` — reading directly from `bundle.manifest.networkConfig`. Anything parsing the JSON had no way to read a VM's network mode.

## Fix

Project the manifest's `NetworkConfig` into `VPhoneBundleReport` as a `network` field, so both `info` and `list` emit it as structured JSON:

```json
"network": { "mode": "nat", "macAddress": "…", "bridgeInterface": null }
```

- `NetworkConfig` gains `Equatable` conformance (`VPhoneBundleReport` is `Equatable`; all members already are).
- The text `net:` line now reads from the same report projection, so both output paths share one source.

The JSON exposes the structured config rather than the `bridged(en0)` string form used in the terminal output — machine-parseable and consistent with the report's other fields.

## Tests

`BundleReportTests` now asserts `network.mode` and adds `carriesNetworkConfig`, covering a bridged config plus JSON round-trip. `swift test --filter BundleReportTests` passes; the full package builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
