### PR TITLE
vphone-cli: Add `fw catalog` with recommended pairings and `--json`

### DIFF
--- a/sources/VPhoneCore/VPhoneFirmwareCatalog.swift
+++ b/sources/VPhoneCore/VPhoneFirmwareCatalog.swift
@@ -31,6 +31,9 @@ public struct VPhoneCloudOSOption: Sendable, Equatable {
 /// The known downloadable iPhone/cloudOS pairings. Prompts show the friendly
 /// `iosName`/`cloudosName`; selection resolves to the URLs.
 public enum VPhoneFirmwareCatalog {
+    /// The iPhone model every catalog IPSW targets.
+    public static let device = "iPhone17,3"
+
     // cloudOS images (one per major); referenced by multiple iPhone builds.
     static let cloud261 = "https://updates.cdn-apple.com/private-cloud-compute/399b664dd623358c3de118ffc114e42dcd51c9309e751d43bc949b98f4e31349"
     static let cloud262 = "https://updates.cdn-apple.com/private-cloud-compute/0cb00f22e0f7a8b33995b49b2bdca77f781ed6093a09c570ac21b0f012bab908"
@@ -66,5 +69,44 @@ public enum VPhoneFirmwareCatalog {
             out.append(VPhoneCloudOSOption(name: p.cloudosName, url: p.cloudosURL))
         }
         return out
+    }
+
+    /// JSON-friendly projection of the catalog: each iOS build with its recommended cloudOS.
+    public static var report: VPhoneFirmwareCatalogReport {
+        VPhoneFirmwareCatalogReport(
+            device: device,
+            pairings: pairings.map {
+                .init(
+                    ios: .init(name: $0.iosName, url: $0.iosURL),
+                    recommendedCloudOS: .init(name: $0.cloudosName, url: $0.cloudosURL))
+            })
+    }
+}
+
+// MARK: - VPhoneFirmwareCatalogReport
+
+/// Codable view of the firmware catalog for `fw catalog --json`.
+public struct VPhoneFirmwareCatalogReport: Codable, Equatable, Sendable {
+    public struct Firmware: Codable, Equatable, Sendable {
+        public let name: String
+        public let url: String
+        public init(name: String, url: String) { self.name = name; self.url = url }
+    }
+
+    public struct Entry: Codable, Equatable, Sendable {
+        public let ios: Firmware
+        public let recommendedCloudOS: Firmware
+        public init(ios: Firmware, recommendedCloudOS: Firmware) {
+            self.ios = ios
+            self.recommendedCloudOS = recommendedCloudOS
+        }
+    }
+
+    public let device: String
+    public let pairings: [Entry]
+
+    public init(device: String, pairings: [Entry]) {
+        self.device = device
+        self.pairings = pairings
     }
 }

--- a/sources/vphone-cli/VPhoneFWCLI.swift
+++ b/sources/vphone-cli/VPhoneFWCLI.swift
@@ -7,7 +7,33 @@ struct VPhoneFWCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "fw",
         abstract: "Firmware pipeline: prepare (download/merge IPSWs) and patch",
-        subcommands: [VPhoneFWPrepareCommand.self, VPhoneFWPatchCommand.self])
+        subcommands: [VPhoneFWCatalogCommand.self, VPhoneFWPrepareCommand.self, VPhoneFWPatchCommand.self])
+}
+
+// MARK: - catalog
+
+struct VPhoneFWCatalogCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "catalog",
+        abstract: "Show the known iOS ↔ cloudOS firmware pairings (recommended per iOS build)")
+
+    @Flag(name: .shortAndLong, help: "Emit JSON") var json = false
+
+    func run() throws {
+        let report = VPhoneFirmwareCatalog.report
+        if json {
+            print(String(decoding: try JSONEncoder().encode(report), as: UTF8.self))
+            return
+        }
+        print("Firmware catalog (\(report.device))")
+        let width = report.pairings.map(\.ios.name.count).max() ?? 0
+        let header = "iOS".padding(toLength: width, withPad: " ", startingAt: 0)
+        print("\(header)  recommended cloudOS")
+        for e in report.pairings {
+            let ios = e.ios.name.padding(toLength: width, withPad: " ", startingAt: 0)
+            print("\(ios)  \(e.recommendedCloudOS.name)")
+        }
+    }
 }
 
 // MARK: - prepare

--- a/tests/VPhoneCoreTests/FirmwareCatalogReportTests.swift
+++ b/tests/VPhoneCoreTests/FirmwareCatalogReportTests.swift
@@ -1,0 +1,25 @@
+@testable import VPhoneCore
+import Foundation
+import Testing
+
+struct FirmwareCatalogReportTests {
+    @Test func mapsEveryPairing() throws {
+        let report = VPhoneFirmwareCatalog.report
+        #expect(report.device == VPhoneFirmwareCatalog.device)
+        #expect(report.pairings.count == VPhoneFirmwareCatalog.pairings.count)
+
+        for (entry, pairing) in zip(report.pairings, VPhoneFirmwareCatalog.pairings) {
+            #expect(entry.ios.name == pairing.iosName)
+            #expect(entry.ios.url == pairing.iosURL)
+            #expect(entry.recommendedCloudOS.name == pairing.cloudosName)
+            #expect(entry.recommendedCloudOS.url == pairing.cloudosURL)
+        }
+    }
+
+    @Test func roundTripsJSON() throws {
+        let report = VPhoneFirmwareCatalog.report
+        let back = try JSONDecoder().decode(
+            VPhoneFirmwareCatalogReport.self, from: try JSONEncoder().encode(report))
+        #expect(back == report)
+    }
+}


### PR DESCRIPTION
## What

Adds a `fw catalog` subcommand that shows the known iOS ↔ cloudOS firmware pairings, with the recommended cloudOS image per iOS build.

- **Human output** — aligned table of each iOS build and its recommended cloudOS (e.g. `iOS 27 beta 4 → cloudOS 26.4`).
- **`--json` / `-j`** — a top-level object `{ "device": "iPhone17,3", "pairings": [ { "ios": {name,url}, "recommendedCloudOS": {name,url} }, … ] }`, carrying the download URLs for both sides of each pairing.

## Where the data comes from

The recommended pairings were already encoded in `VPhoneFirmwareCatalog.pairings` (`sources/VPhoneCore/VPhoneFirmwareCatalog.swift`) — each entry ties an iOS IPSW to the cloudOS image it should be paired with. This command just projects that existing source of truth; no pairing data was invented.

## Changes

- `sources/VPhoneCore/VPhoneFirmwareCatalog.swift` — add a `device` constant, a `Codable` `VPhoneFirmwareCatalogReport` model, and a `report` builder mapping the existing pairings.
- `sources/vphone-cli/VPhoneFWCLI.swift` — add `VPhoneFWCatalogCommand` under the `fw` group, following the existing `vm list --json` idiom (`@Flag var json`, `JSONEncoder()`).
- `tests/VPhoneCoreTests/FirmwareCatalogReportTests.swift` — verify the report maps every pairing and round-trips through JSON.

## Verification

- `swift build` compiles clean (pre-existing unrelated warning in `VPhoneMenuRecord.swift`).
- New tests pass (`swift test --filter FirmwareCatalogReportTests`).
- Ran the built binary: human table, `--json` structure (valid JSON, 18 entries), `-j` short flag, and `fw --help` listing all confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)