### PR TITLE
vphone-cli: Add `--disk-size` to `vm create`

### DIFF
--- a/sources/vphone-cli/VPhoneVMCreateCLI.swift
+++ b/sources/vphone-cli/VPhoneVMCreateCLI.swift
@@ -16,6 +16,7 @@ struct VPhoneVMCreateCommand: ParsableCommand {
     @Option(name: [.customShort("V"), .long], help: "variant: regular | dev | jb | exp | less") var variant: String = "regular"
     @Option(name: .shortAndLong, help: "iPhone IPSW URL or local path") var iphoneSource: String?
     @Option(name: .shortAndLong, help: "cloudOS IPSW URL or local path") var cloudosSource: String?
+    @Option(name: .shortAndLong, help: "Disk size (GB)") var diskSize: UInt64 = 64
     @Option(name: .shortAndLong, help: "sudo password for the CFW host-mount install (via askpass; never logged)")
     var sudoPassword: String?
     @Option(name: [.customShort("b"), .long], help: "(exp only) rewrite ProductBuildVersion to this build id") var spoofBuild: String?
@@ -41,7 +42,8 @@ struct VPhoneVMCreateCommand: ParsableCommand {
             iphoneSource: sources.iphoneSource, cloudosSource: sources.cloudosSource,
             sudoPassword: sudoPassword, spoofBuild: spoofBuild, forceDSCMaxSlide: forceDSCMaxSlide,
             rootPopup: rootPopup,
-            interactive: interactive, verbosity: VPhoneVerbosity(count: verboseCount),
+            interactive: interactive, diskSizeGB: diskSize,
+            verbosity: VPhoneVerbosity(count: verboseCount),
             keepArtifacts: keepArtifacts))
     }
 }


### PR DESCRIPTION
## What

Adds a `-d/--disk-size <GB>` option to `vphone-cli vm create` (default 64).

## Why

`vm create` constructed the orchestrator `Options` without ever setting `diskSizeGB`, so the guest `Disk.img` was pinned to the 64 GB default regardless of intent. The full downstream plumbing already existed — `Options.diskSizeGB` → `NewBundleSpec.diskSizeGB` → the sparse `Disk.img` `truncate` in `VPhoneBundleOps` — so this only exposes the flag on the command and threads it through. The sibling `vm new` command already had this option; this brings `vm create` in line.

## Changes

- `sources/vphone-cli/VPhoneVMCreateCLI.swift`: add `@Option --disk-size` (matches `vm new` naming/convention) and pass `diskSizeGB: diskSize` into `orchestrator.run(.init(...))`.

## Verification

- `make build` — compiles and signs OK.
- `vphone-cli vm create --help` now lists `-d, --disk-size <disk-size>  Disk size (GB) (default: 64)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)