### PR TITLE
vphone-cli: Add --headless boot option

### DIFF
--- a/sources/vphone-cli/VPhoneCLI.swift
+++ b/sources/vphone-cli/VPhoneCLI.swift
@@ -43,6 +43,9 @@ struct VPhoneBootCLI: ParsableCommand {
     @Flag(name: .shortAndLong, help: "Boot into DFU mode")
     var dfu: Bool = false
 
+    @Flag(name: .customLong("headless"), help: "Boot without a VM window or menu bar")
+    var headless: Bool = false
+
     @Option(help: "Kernel GDB debug stub port on host (omit for system-assigned port; valid: 6000...65535)")
     var kernelDebugPort: Int?
 
@@ -61,9 +64,9 @@ struct VPhoneBootCLI: ParsableCommand {
     @Flag(name: .customLong("no-vphoned"), help: "Exclude vphoned usage (patchless-only).")
     var noVphoned: Bool = false
 
-    /// DFU mode runs headless (no GUI).
+    /// DFU mode is always headless.
     var noGraphics: Bool {
-        dfu
+        dfu || headless
     }
 
     var installPackageURL: URL? {

--- a/sources/vphone-cli/VPhoneCreateOrchestrator.swift
+++ b/sources/vphone-cli/VPhoneCreateOrchestrator.swift
@@ -534,6 +534,8 @@ public struct VPhoneCreateOrchestrator {
         let configURL = bundleURL.appendingPathComponent("config.plist")
         var args = ["--config", configURL.path]
         if isLess { args += ["--variant", "less"] }
+        // --interactive keeps the window: it is the operator's only boot-progress cue.
+        if !options.interactive { args.append("--headless") }
 
         if options.interactive {
             print("[*] press Enter to start VM, after the VM has finished booting, press Enter again to finish last stage")
@@ -580,9 +582,9 @@ public struct VPhoneCreateOrchestrator {
 
     private func runBootAnalysis(bundleURL: URL, verbosity v: VPhoneVerbosity) throws {
         let configURL = bundleURL.appendingPathComponent("config.plist")
-        trace("spawn \(selfExecutable.path) --config \(configURL.path) (guest serial: off)", v)
+        trace("spawn \(selfExecutable.path) --config \(configURL.path) --headless (guest serial: off)", v)
         let vm = VPhoneManagedProcess(
-            selfExecutable, ["--config", configURL.path], cwd: bundleURL, echo: false)
+            selfExecutable, ["--config", configURL.path, "--headless"], cwd: bundleURL, echo: false)
         try vm.start()
         defer { vm.terminate() }
 

--- a/sources/vphone-cli/VPhoneVMLaunchCLI.swift
+++ b/sources/vphone-cli/VPhoneVMLaunchCLI.swift
@@ -9,6 +9,7 @@ struct VPhoneVMLaunchCommand: ParsableCommand {
     @OptionGroup var lib: VPhoneLibraryOption
     @Argument(help: "VM name") var name: String?
     @Flag(name: .shortAndLong, help: "Boot into DFU mode (headless)") var dfu = false
+    @Flag(name: .customLong("headless"), help: "Boot without a VM window or menu bar") var headless = false
     @Option(name: [.customShort("V"), .long], help: "Firmware variant") var variant: String?
     @Flag(name: .customLong("no-vphoned"), help: "Do not stage/use vphoned") var noVphoned = false
     @Option(help: "Kernel GDB debug stub port on host (omit for system-assigned; valid: 6000...65535)")
@@ -61,6 +62,7 @@ struct VPhoneVMLaunchCommand: ParsableCommand {
 
         var args = ["--config", bundle.configURL.path]
         if dfu { args.append("--dfu") }
+        if headless { args.append("--headless") }
         if let variant { args += ["--variant", variant] }
         if noVphoned { args.append("--no-vphoned") }
         if let kernelDebugPort { args += ["--kernel-debug-port", String(kernelDebugPort)] }


### PR DESCRIPTION
Adds a `--headless` flag to boot a VM with no window or menu bar.

The guest still gets its display device, so the boot chain is unchanged — only the AppKit window, menu bar, and Dock presence are skipped (activation policy becomes `.prohibited`). Internally this just widens the existing `noGraphics` condition, which until now was only ever true for `--dfu`.

## Surface

- `vphone-cli boot --headless`
- `vphone-cli vm launch <name> --headless`
- `vm create` now uses it for both setup boots (first boot and boot analysis). The DFU restore boot was already headless.

`vm create --interactive` deliberately keeps the window: that mode asks the operator to press Enter "once the VM is fully booted", and since guest serial isn't teed during create, the window is their only progress cue.

## Caveat

The `<bundle>/vphone.sock` host control socket does not start in headless mode — its handler needs the `VZVirtualMachineView` capture view, which only exists in the graphics path. Anything driving a VM through that socket (e.g. vphone-mcp) should keep using a windowed boot. Happy to add an offscreen capture path in a follow-up if that's wanted.

## Testing

Booted `vm launch <name> --headless` on an iOS 26.1 `regular` VM: guest reached the `bash-4.4#` serial prompt with 0 panics, no window and no Dock entry were created, and `vm stop` shut it down cleanly. That prompt is the same marker `runBootAnalysis` waits for, so the `vm create` path is exercised by the same run.

`swift test` shows an identical set of 16 pre-existing failures before and after this change (they need the device-only `ipsws/` fixture tree, plus two path-assumption tests); the test targets depend only on `FirmwarePatcher`/`VPhoneCore`, not the executable target touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)