### PR TITLE
vphone-cli: Show fw prepare output during vm create

### DIFF
--- a/sources/vphone-cli/VPhoneCreateOrchestrator.swift
+++ b/sources/vphone-cli/VPhoneCreateOrchestrator.swift
@@ -317,9 +317,10 @@ public struct VPhoneCreateOrchestrator {
         if options.keepArtifacts { env["VPHONE_KEEP_ARTIFACTS"] = "1" }
 
         trace("spawn /bin/bash \(resources.fwPrepareScript.path) (env keys: VPHONE_PYTHON, IPSW_DIR, VPHONE_SEAL_DIR)", v)
+        // Always streamed — silence during a multi-GB download reads as a hang.
         let code = try VPhoneProcessRunner.runStreaming(
             URL(fileURLWithPath: "/bin/bash"), [resources.fwPrepareScript.path], cwd: bundleURL, env: env,
-            echo: v.showsToolDetail)
+            echo: true)
         guard code == 0 else { throw VPhoneCreateError.fwPrepareFailed(code) }
         print("[+] Firmware prepared (iPhone + cloudOS merged into bundle).")
     }


### PR DESCRIPTION
`vm create` looks hung during its longest phase. Fixes that by streaming the `fw prepare` output.

## Cause

`runFWPrepare` passed `echo: v.showsToolDetail` to `runStreaming`, which is `false` at default verbosity. `runStreaming` with `echo: false` points the child's stdout *and* stderr at `FileHandle.nullDevice`, so the aria2c/curl/wget progress bar went to `/dev/null` along with everything else. The result is a multi-GB IPSW download that prints nothing for many minutes — indistinguishable from a hang.

Standalone `vphone-cli fw prepare` never had this problem: it floors its verbosity at `.info` (`VPhoneFWCLI.swift:58`) precisely so its output always shows. This was an inconsistency between the two entry points into the same script; this change brings `vm create` in line.

## Why unconditional rather than a new flag

`fw_prepare.sh` is status-line based — roughly 40 `echo`s across the whole phase, `unzip -oq` for extraction, and no per-file loops — so always-on streaming adds progress rather than noise. Because `echo: true` inherits stdio instead of piping, aria2c's carriage-return progress line updates in place exactly as it does when the script is run by hand.

## Testing

Ran `vm create` at default verbosity (no `-v`) against cached IPSWs. Previously silent, now:

```
=== prepare_firmware ===
  Device:   iPhone17,3
  ...
==> Skipping: '.../iPhone17,3_26.1_23B85_Restore.ipsw' already exists.
==> Extracting iPhone17,3_26.1_23B85_Restore.ipsw ...
```

The "Skipping / already exists" line comes from the same `fetch` / `download_file` path that renders the progress bar for an uncached IPSW.

Not touched here: the restore and CFW-install phases are still gated on `-v`. The restore in particular sits at `[*] Restoring...` for a long time and has the same quality, but it's a separate call site and a separate judgement call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)