### PR TITLE
Stream CFW install log live under --root-popup

### DIFF
--- a/sources/VPhoneCore/VPhoneProcessRunner.swift
+++ b/sources/VPhoneCore/VPhoneProcessRunner.swift
@@ -179,8 +179,12 @@ public enum VPhoneProcessRunner {
         var tokens = env.sorted { $0.key < $1.key }.map { "\($0.key)=\(shQuote($0.value))" }
         tokens.append(shQuote(executable.path))
         tokens += args.map(shQuote)
+        var command = tokens.joined(separator: " ")
+        if echo, isatty(STDOUT_FILENO) != 0, let tty = ttyname(STDOUT_FILENO) {
+            command += " > \(shQuote(String(cString: tty))) 2>&1"
+        }
         // Escape the /bin/sh command for the AppleScript string literal (\ then ").
-        let appleEscaped = tokens.joined(separator: " ")
+        let appleEscaped = command
             .replacingOccurrences(of: "\\", with: "\\\\")
             .replacingOccurrences(of: "\"", with: "\\\"")
         let source = "do shell script \"\(appleEscaped)\" with administrator privileges"


### PR DESCRIPTION
## Problem

During `vm create`, the **CFW install** stage shows nothing for several minutes and then prints a single line. Every other stage streams normally.

`--root-popup` routes the install through `VPhoneProcessRunner.runWithAdminPrivileges`, i.e. `osascript -e 'do shell script … with administrator privileges'`. That command runs under a helper process which inherits none of our file descriptors, so AppleScript can only return its output as a value — after the command exits. It also rewrites every `\n` to `\r` on the way out.

That second part is what reduces the stage to one line. A lone `\r` is legitimately a progress-bar overwrite, so any reader applying terminal semantics — including the vphone-ws log view — treats each line as overwriting the previous one:

```
$ osascript -e 'do shell script "echo first; sleep 2; echo second; sleep 2; echo third"'
  4.08s  b'first\rsecond\rthird\n'     # one blob, only at exit
```

## Fix

Our stdout is already a pty (vphone-ws creates one precisely so tools flush live), and `ttyname(STDOUT_FILENO)` yields an absolute device path the privileged shell can open. Naming it in the command is enough:

```swift
if echo, isatty(STDOUT_FILENO) != 0, let tty = ttyname(STDOUT_FILENO) {
    command += " > \(shQuote(String(cString: tty))) 2>&1"
}
```

```
  0.07s  b'first\n'
  2.07s  b'second\n'
  4.08s  b'third\n'
```

Output arrives as produced, with newlines intact, and `isatty()` is now true for the script's children so they line-buffer instead of block-buffering. Gated on `echo` so quiet verbosity still suppresses output, and skipped when stdout is not a tty (falls back to today's behaviour). No temp files, no extra pty, no reader threads.

Also benefits `vphone-cli cfw install --root-popup` (`VPhoneRestoreCLI`), which uses the same helper.

## Verification

Reproduced the GUI's exact setup — child stdout on a raw pty (`cfmakeraw`, as `SystemStreamingRunner` does), reading the master with timestamps. The two traces above are that script's real output, before and after.

`swift build --target VPhoneCore` is clean and all 6 `ProcessRunnerTests` pass. Three `ResourcesTests` failures in the wider suite are pre-existing and unrelated — they assert an installed `/Applications/vphone-cli.app` path and fail identically with this change stashed.

## Not addressed

`do shell script` raises an AppleScript error on any nonzero exit, so this path still reports osascript's status rather than the script's — `cfwInstallFailed` always says `exit 1`. This change doesn't worsen it (the script's stderr now reaches the terminal instead of being buried in the AppleScript error text), but the number is still wrong. Capturing the real status needs somewhere to park `$?`, which seemed out of scope here.

## Test plan

- [x] `vm create` via the GUI (`--root-popup`) and confirm the Install CFW stage streams as it runs
- [x] `vm create` with `--sudo-password` and without either flag, confirming both unchanged
- [x] Default (quiet) verbosity still shows no CFW install output

🤖 Generated with [Claude Code](https://claude.com/claude-code)