### PR TITLE
vphone-cli: Fix libkeystone in the managed venv, add cmake dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Boot a virtual iPhone via Apple's Virtualization.framework using PCC research VM
 **Dependencies:**
 
 ```bash
-brew install python@3.13 aria2 wget gnu-tar openssl@3 ldid-procursus sshpass keystone libusb ipsw zstd
+brew install python@3.13 aria2 wget gnu-tar openssl@3 ldid-procursus sshpass keystone cmake libusb ipsw zstd
 ```
 
 ## Install

--- a/docs/README_ja.md
+++ b/docs/README_ja.md
@@ -17,7 +17,7 @@ PCC リサーチ VM インフラストラクチャを使用し、Apple の Virtu
 **依存関係:**
 
 ```bash
-brew install python@3.13 aria2 wget gnu-tar openssl@3 ldid-procursus sshpass keystone libusb ipsw zstd
+brew install python@3.13 aria2 wget gnu-tar openssl@3 ldid-procursus sshpass keystone cmake libusb ipsw zstd
 ```
 
 ## インストール

--- a/docs/README_ko.md
+++ b/docs/README_ko.md
@@ -17,7 +17,7 @@ PCC 리서치 VM 인프라를 사용하여 Apple의 Virtualization.framework로 
 **의존성:**
 
 ```bash
-brew install python@3.13 aria2 wget gnu-tar openssl@3 ldid-procursus sshpass keystone libusb ipsw zstd
+brew install python@3.13 aria2 wget gnu-tar openssl@3 ldid-procursus sshpass keystone cmake libusb ipsw zstd
 ```
 
 ## 설치

--- a/docs/README_zh.md
+++ b/docs/README_zh.md
@@ -17,7 +17,7 @@
 **依赖：**
 
 ```bash
-brew install python@3.13 aria2 wget gnu-tar openssl@3 ldid-procursus sshpass keystone libusb ipsw zstd
+brew install python@3.13 aria2 wget gnu-tar openssl@3 ldid-procursus sshpass keystone cmake libusb ipsw zstd
 ```
 
 ## 安装

--- a/scripts/setup_tools.sh
+++ b/scripts/setup_tools.sh
@@ -27,7 +27,7 @@ ensure_repo_submodule() {
 
 echo "[1/4] Checking brew packages..."
 
-BREW_PACKAGES=(aria2 gnu-tar openssl@3 ldid-procursus sshpass zstd)
+BREW_PACKAGES=(aria2 gnu-tar openssl@3 ldid-procursus sshpass zstd cmake)
 BREW_MISSING=()
 
 for pkg in "${BREW_PACKAGES[@]}"; do

--- a/sources/VPhoneCore/VPhoneResources.swift
+++ b/sources/VPhoneCore/VPhoneResources.swift
@@ -109,6 +109,71 @@ public struct VPhoneResources: Sendable {
         return (try? VPhoneProcessRunner.runCapturing(python, ["-c", probe]))?.succeeded == true
     }
 
+    /// Must assemble, not just import — a bindings-only install imports fine
+    /// and then fails inside `fw patch`.
+    func keystoneIsUsable(_ python: URL) -> Bool {
+        let probe = "from keystone import Ks, KS_ARCH_ARM64, KS_MODE_LITTLE_ENDIAN; import sys; "
+            + "sys.exit(0 if bytes(Ks(KS_ARCH_ARM64, KS_MODE_LITTLE_ENDIAN).asm('nop')[0]) else 1)"
+        return (try? VPhoneProcessRunner.runCapturing(python, ["-c", probe]))?.succeeded == true
+    }
+
+    func venvIsUsable(_ python: URL) -> Bool {
+        pythonIsUsable(python) && keystoneIsUsable(python)
+    }
+
+    // MARK: - keystone native library
+
+    /// Older bottles ship only the static archive.
+    private func homebrewKeystoneLibs() -> (dylib: URL?, archive: URL?) {
+        for prefix in ["/opt/homebrew/opt/keystone/lib", "/usr/local/opt/keystone/lib"] {
+            let dir = URL(fileURLWithPath: prefix)
+            guard let names = try? FileManager.default.contentsOfDirectory(atPath: dir.path) else { continue }
+            let dylib = names.first { $0.hasPrefix("libkeystone") && $0.hasSuffix(".dylib") }
+            let archive = names.first { $0 == "libkeystone.a" }
+            if dylib != nil || archive != nil {
+                return (dylib.map(dir.appendingPathComponent), archive.map(dir.appendingPathComponent))
+            }
+        }
+        return (nil, nil)
+    }
+
+    /// Asked of the interpreter: `import keystone` is what's broken here.
+    private func keystonePackageDir(_ python: URL) -> URL? {
+        let probe = "import sysconfig; print(sysconfig.get_paths()['purelib'])"
+        guard let r = try? VPhoneProcessRunner.runCapturing(python, ["-c", probe]), r.succeeded else { return nil }
+        let purelib = r.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !purelib.isEmpty else { return nil }
+        return URL(fileURLWithPath: purelib).appendingPathComponent("keystone")
+    }
+
+    /// PyPI has no arm64 macOS wheel and the sdist ignores its build's exit
+    /// status, so a failed native build still installs bindings alone and pip
+    /// reports success. Same recovery as scripts/setup_venv.sh.
+    func repairKeystone(_ python: URL) -> Bool {
+        guard let pkgDir = keystonePackageDir(python),
+              FileManager.default.fileExists(atPath: pkgDir.path) else { return false }
+        let dest = pkgDir.appendingPathComponent("libkeystone.dylib")
+        let libs = homebrewKeystoneLibs()
+
+        if let dylib = libs.dylib {
+            try? FileManager.default.removeItem(at: dest)
+            guard (try? FileManager.default.copyItem(at: dylib, to: dest)) != nil else { return false }
+            try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: dest.path)
+        } else if let archive = libs.archive {
+            let r = try? VPhoneProcessRunner.runCapturing(
+                URL(fileURLWithPath: "/usr/bin/clang"),
+                ["-shared", "-o", dest.path, "-Wl,-all_load", archive.path,
+                 "-lc++", "-install_name", "@rpath/libkeystone.dylib"])
+            guard r?.succeeded == true else { return false }
+        } else {
+            return false
+        }
+
+        guard keystoneIsUsable(python) else { return false }
+        FileHandle.standardError.write(Data("[+] Repaired keystone native library: \(dest.path)\n".utf8))
+        return true
+    }
+
     /// Resolve a python with working deps: an explicit `VPHONE_PYTHON`, the dev
     /// repo `.venv`, the managed per-user venv, else provision the managed venv
     /// on this machine. Never silently falls back to a stale system python.
@@ -118,8 +183,13 @@ public struct VPhoneResources: Sendable {
             if pythonIsUsable(u) { return u }
         }
         let devVenv = base.appendingPathComponent(".venv/bin/python3")
-        if pythonIsUsable(devVenv) { return devVenv }
-        if pythonIsUsable(managedVenvPython) { return managedVenvPython }
+        if venvIsUsable(devVenv) { return devVenv }
+        // Repair in place before rebuilding — a missing dylib is not worth a
+        // full re-install.
+        if pythonIsUsable(managedVenvPython),
+           keystoneIsUsable(managedVenvPython) || repairKeystone(managedVenvPython) {
+            return managedVenvPython
+        }
         return try bootstrapManagedVenv()
     }
 
@@ -155,6 +225,11 @@ public struct VPhoneResources: Sendable {
             }
             guard pythonIsUsable(py) else {
                 lastError = "venv from \(host.path) still lacks a usable ipsw_parser (too old?)"; continue
+            }
+            guard keystoneIsUsable(py) || repairKeystone(py) else {
+                lastError = "venv from \(host.path) has no working libkeystone — "
+                    + "`brew install keystone`, or install cmake so pip can build it"
+                continue
             }
             log("[+] Python environment ready: \(py.path)")
             return py

--- a/tests/VPhoneCoreTests/ResourcesTests.swift
+++ b/tests/VPhoneCoreTests/ResourcesTests.swift
@@ -32,6 +32,16 @@ struct ResourcesTests {
         #expect(r.toolsBinDir.path == r.base.appendingPathComponent(".tools/bin").path)
     }
 
+    /// These all shell out; a missing interpreter must return false, not throw.
+    @Test func venvProbesAreTotalForAMissingInterpreter() {
+        let r = VPhoneResources(base: URL(fileURLWithPath: "/x"))
+        let missing = URL(fileURLWithPath: "/nonexistent/bin/python3")
+        #expect(r.pythonIsUsable(missing) == false)
+        #expect(r.keystoneIsUsable(missing) == false)
+        #expect(r.venvIsUsable(missing) == false)
+        #expect(r.repairKeystone(missing) == false)
+    }
+
     @Test func managedVenvDefaultsUnderDotVphone() {
         // The override env var would change this; only assert the default.
         if ProcessInfo.processInfo.environment["VPHONE_VENV_DIR"] != nil { return }


### PR DESCRIPTION
The unified tool provisions `~/.vphone/venv` itself and never runs `setup_venv.sh`, so it lost that script's libkeystone handling.

**Why it breaks.** PyPI has no arm64 macOS wheel for `keystone-engine` (only `macosx_10_14_x86_64`), so pip builds from the sdist, whose `make-share.sh` invokes `cmake`. Without cmake the build fails — silently, because `setup.py` calls `subprocess.call` without checking the exit status and then copies via a glob that matches nothing. pip reports success, having installed bindings with no native library.

`bootstrapManagedVenv` then verifies with `pythonIsUsable`, which only probes `ipsw_parser`, so that venv is cached as good and fails much later inside `fw patch`.

**Fix.**

- Add `cmake` to the brew deps (`setup_tools.sh` + READMEs) so the build succeeds in the first place.
- `keystoneIsUsable` probes that keystone can *assemble*, not merely import.
- `repairKeystone` recovers an already-broken venv: copy a Homebrew dylib if the bottle ships one, else link from `libkeystone.a` — same as `setup_venv.sh`. Older bottles ship only the static archive, hence both branches. Repairs in place before falling back to a full rebuild.

Nothing here fires when the pip build works.

Worth knowing: a failed build also caches a bindings-only wheel (9 KB, zero dylib entries) as a success, so the breakage survives installing cmake until the pip cache is purged. The repair fixes those machines anyway.

**Testing.** Repaired a venv with its dylibs deleted, in place, leaving the real one byte-identical. Verified the clang-from-archive branch assembles (`nop` → `1f2003d5`). Reproduced the true origin — pip cache cleared, cmake off `PATH` — pip exited 0 with bindings-only, the provisioning guard caught it and recovered. `swift test`: 176 tests, same 16 pre-existing failures as base.

some of this changes were based on the fix in https://github.com/Lakr233/vphone-cli/pull/331

🤖 Generated with [Claude Code](https://claude.com/claude-code)