### PR TITLE
frida: Add build.frida.re as a Sileo/apt source at first boot

### DIFF
--- a/scripts/vphone_jb_setup.sh
+++ b/scripts/vphone_jb_setup.sh
@@ -229,6 +229,15 @@ else
     log "  Havoc source already present"
 fi
 
+FRIDA_LIST="$(dirname "$HAVOC_LIST")/frida.list"
+if ! grep -rIl 'build.frida.re' /etc/apt /var/jb/etc/apt 2>/dev/null | grep -q .; then
+    mkdir -p "$(dirname "$FRIDA_LIST")"
+    printf '%s\n' 'deb https://build.frida.re/ ./' > "$FRIDA_LIST"
+    log "  Frida source added: $FRIDA_LIST"
+else
+    log "  Frida source already present"
+fi
+
 apt-get -o Acquire::AllowInsecureRepositories=true \
     -o Acquire::AllowDowngradeToInsecureRepositories=true \
     update -qq 2>&1 || log "  apt update exited with $?"


### PR DESCRIPTION
The JB first-boot setup (`scripts/vphone_jb_setup.sh`) now adds the Frida repo as an apt/Sileo source next to the existing Havoc source, so Frida packages can be installed and updated from Sileo/apt on a jailbroken VM:

```
deb https://build.frida.re/ ./
```

- Written to `frida.list` in the same sources dir the Havoc source uses (`/var/jb/etc/apt/sources.list.d` or `/etc/apt/sources.list.d`).
- Idempotent — skipped if a `build.frida.re` source is already present.
- Picked up by the existing `apt-get update` run (already passes `AllowInsecureRepositories=true`), so no extra update pass is needed.

Scoped to JB/EXP only, since this first-boot script is only deployed for those variants.