### PR TITLE
vm export: add --compress preset (fast/balanced/max)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ vphone-cli vm info myphone                  # show one VM
 vphone-cli vm new myphone                   # create an empty bundle (cpu/mem/disk options)
 vphone-cli vm config myphone --cpu 8 --memory 8192
 vphone-cli vm clone myphone myphone-2       # fast APFS clone, fresh device identity
-vphone-cli vm export myphone --out myphone.tar.xz   # xz -9; skips restore dir + staging files
-vphone-cli vm import --in myphone.tar.xz --name restored
+vphone-cli vm export myphone --out myphone.tzst   # zstd balanced (--compress fast|balanced|max); skips restore dir + staging files
+vphone-cli vm import --in myphone.tzst --name restored
 vphone-cli vm rename myphone iphone16
 vphone-cli vm delete iphone16
 ```

--- a/docs/README_ja.md
+++ b/docs/README_ja.md
@@ -60,8 +60,8 @@ vphone-cli vm info myphone                  # 1 つの VM を表示
 vphone-cli vm new myphone                   # 空のバンドルを作成（cpu/mem/disk オプション）
 vphone-cli vm config myphone --cpu 8 --memory 8192
 vphone-cli vm clone myphone myphone-2       # 高速 APFS クローン、新しいデバイスアイデンティティ
-vphone-cli vm export myphone --out myphone.tar.xz   # xz -9; 復元ディレクトリ + ステージングファイルをスキップ
-vphone-cli vm import --in myphone.tar.xz --name restored
+vphone-cli vm export myphone --out myphone.tzst   # zstd balanced (--compress fast|balanced|max); 復元ディレクトリ + ステージングファイルをスキップ
+vphone-cli vm import --in myphone.tzst --name restored
 vphone-cli vm rename myphone iphone16
 vphone-cli vm delete iphone16
 ```

--- a/docs/README_ko.md
+++ b/docs/README_ko.md
@@ -60,8 +60,8 @@ vphone-cli vm info myphone                  # VM 하나 표시
 vphone-cli vm new myphone                   # 빈 번들 생성 (cpu/mem/disk 옵션)
 vphone-cli vm config myphone --cpu 8 --memory 8192
 vphone-cli vm clone myphone myphone-2       # 빠른 APFS 복제, 새로운 기기 식별자
-vphone-cli vm export myphone --out myphone.tar.xz   # xz -9; restore 디렉토리 + 스테이징 파일 건너뜀
-vphone-cli vm import --in myphone.tar.xz --name restored
+vphone-cli vm export myphone --out myphone.tzst   # zstd balanced (--compress fast|balanced|max); restore 디렉토리 + 스테이징 파일 건너뜀
+vphone-cli vm import --in myphone.tzst --name restored
 vphone-cli vm rename myphone iphone16
 vphone-cli vm delete iphone16
 ```

--- a/docs/README_zh.md
+++ b/docs/README_zh.md
@@ -60,8 +60,8 @@ vphone-cli vm info myphone                  # 显示某台虚拟机
 vphone-cli vm new myphone                   # 创建一个空 bundle（cpu/内存/磁盘选项）
 vphone-cli vm config myphone --cpu 8 --memory 8192
 vphone-cli vm clone myphone myphone-2       # 快速 APFS 克隆，全新设备标识
-vphone-cli vm export myphone --out myphone.tar.xz   # xz -9；跳过 restore 目录 + 暂存文件
-vphone-cli vm import --in myphone.tar.xz --name restored
+vphone-cli vm export myphone --out myphone.tzst   # zstd balanced（--compress fast|balanced|max）；跳过 restore 目录 + 暂存文件
+vphone-cli vm import --in myphone.tzst --name restored
 vphone-cli vm rename myphone iphone16
 vphone-cli vm delete iphone16
 ```

--- a/sources/VPhoneCore/VPhoneBundleOps.swift
+++ b/sources/VPhoneCore/VPhoneBundleOps.swift
@@ -167,6 +167,20 @@ public enum VPhoneBundleOps {
 
     // MARK: - Export / Import
 
+    /// Compression preset for `export`. All import transparently: `importArchive`
+    /// auto-detects the compressor via `tar -tf`/`-xf`. `threads=0` → all cores.
+    public enum ExportCompression: String, CaseIterable, Sendable {
+        case fast, balanced, max
+
+        var tarArgs: [String] {
+            switch self {
+            case .fast:     ["--zstd", "--options", "zstd:compression-level=3,zstd:threads=0"]
+            case .balanced: ["--zstd", "--options", "zstd:compression-level=19,zstd:threads=0"]
+            case .max:      ["-J", "--options", "xz:compression-level=9,xz:threads=0"]
+            }
+        }
+    }
+
     /// Regenerable staging artifacts that never need to travel in an export:
     /// `.vphoned.signed` is re-staged on the next launch, and the CFW install
     /// inputs/temp are consumed at install time (the result already lives in
@@ -174,12 +188,11 @@ public enum VPhoneBundleOps {
     static let exportExcludePatterns = ["*.vphoned.signed", "*cfw_input*", "*cfw_jb_input*", "*.cfw_temp*"]
 
     public static func export(
-        bundleNamed name: String, to outFile: URL, includeIPSW: Bool, in library: VPhoneLibrary
+        bundleNamed name: String, to outFile: URL, includeIPSW: Bool,
+        compression: ExportCompression = .balanced, in library: VPhoneLibrary
     ) throws {
         _ = try library.bundle(named: name)  // validate it exists
-        // xz at max level, multithreaded (threads=0 → all cores) — the densest
-        // compressor libarchive offers, for a multi-GB Disk.img.
-        var args = ["-cf", outFile.path, "-J", "--options", "xz:compression-level=9,xz:threads=0"]
+        var args = ["-cf", outFile.path] + compression.tarArgs
         if !includeIPSW { args += ["--exclude", "*_Restore*"] }
         for pattern in exportExcludePatterns { args += ["--exclude", pattern] }
         args += ["-C", library.root.path, name]

--- a/sources/vphone-cli/VPhoneVMTransferCLI.swift
+++ b/sources/vphone-cli/VPhoneVMTransferCLI.swift
@@ -21,6 +21,8 @@ struct VPhoneVMCloneCommand: ParsableCommand {
     }
 }
 
+extension VPhoneBundleOps.ExportCompression: ExpressibleByArgument {}
+
 struct VPhoneVMExportCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "export", abstract: "Export a VM bundle to a .tgz archive")
@@ -28,12 +30,15 @@ struct VPhoneVMExportCommand: ParsableCommand {
     @OptionGroup var lib: VPhoneLibraryOption
     @Argument(help: "VM name") var name: String?
     @Option(name: .shortAndLong, help: "output archive path") var out: String
+    @Option(name: .shortAndLong, help: "compression preset: fast | balanced | max")
+    var compress: VPhoneBundleOps.ExportCompression = .balanced
     @Flag(help: "include the *_Restore* IPSW directory") var includeIpsw = false
 
     func run() throws {
         let name = try VPhoneVMSelection.resolveExisting(name, in: lib.library)
         try VPhoneBundleOps.export(
-            bundleNamed: name, to: URL(fileURLWithPath: out), includeIPSW: includeIpsw, in: lib.library)
+            bundleNamed: name, to: URL(fileURLWithPath: out), includeIPSW: includeIpsw,
+            compression: compress, in: lib.library)
         print("exported \(name) → \(out)")
     }
 }

--- a/tests/VPhoneCoreTests/BundleOpsTests.swift
+++ b/tests/VPhoneCoreTests/BundleOpsTests.swift
@@ -361,4 +361,62 @@ struct BundleOpsTests {
             _ = try VPhoneBundleOps.importArchive(from: archive, name: nil, in: VPhoneLibrary(root: root))
         }
     }
+
+    // MARK: - Compression presets
+
+    private static let zstdMagic: [UInt8] = [0x28, 0xB5, 0x2F, 0xFD]
+    private static let xzMagic: [UInt8] = [0xFD, 0x37, 0x7A, 0x58, 0x5A, 0x00]
+
+    private func magic(_ url: URL, _ n: Int) throws -> [UInt8] {
+        Array(try Data(contentsOf: url).prefix(n))
+    }
+
+    private func exportAndImport(
+        _ compression: VPhoneBundleOps.ExportCompression?
+    ) throws -> (archive: URL, imported: VPhoneBundle) {
+        let root = try makeRoot()
+        let rom = try fakeROM(); let seprom = try fakeROM()
+        let lib = VPhoneLibrary(root: root)
+        _ = try VPhoneBundleOps.create(
+            .init(name: "orig", cpuCount: 6, memoryMB: 2048, diskSizeGB: 1,
+                  romSource: rom, sepromSource: seprom), in: lib)
+        let archive = root.appendingPathComponent("orig.archive")
+        if let compression {
+            try VPhoneBundleOps.export(
+                bundleNamed: "orig", to: archive, includeIPSW: false, compression: compression, in: lib)
+        } else {
+            try VPhoneBundleOps.export(bundleNamed: "orig", to: archive, includeIPSW: false, in: lib)
+        }
+        let dstRoot = try makeRoot()
+        let imported = try VPhoneBundleOps.importArchive(
+            from: archive, name: "copy", in: VPhoneLibrary(root: dstRoot))
+        return (archive, imported)
+    }
+
+    @Test func exportDefaultsToBalancedZstd() throws {
+        let (archive, imported) = try exportAndImport(nil)
+        #expect(try magic(archive, 4) == Self.zstdMagic)
+        #expect(imported.manifest.cpuCount == 6)
+    }
+
+    @Test func exportFastProducesZstdAndRoundTrips() throws {
+        let (archive, imported) = try exportAndImport(.fast)
+        #expect(try magic(archive, 4) == Self.zstdMagic)
+        #expect(imported.manifest.cpuCount == 6)
+    }
+
+    @Test func exportMaxProducesXzAndRoundTrips() throws {
+        let (archive, imported) = try exportAndImport(.max)
+        #expect(try magic(archive, 6) == Self.xzMagic)
+        #expect(imported.manifest.cpuCount == 6)
+    }
+
+    @Test func compressionPresetTarArgs() {
+        #expect(VPhoneBundleOps.ExportCompression.fast.tarArgs
+            == ["--zstd", "--options", "zstd:compression-level=3,zstd:threads=0"])
+        #expect(VPhoneBundleOps.ExportCompression.balanced.tarArgs
+            == ["--zstd", "--options", "zstd:compression-level=19,zstd:threads=0"])
+        #expect(VPhoneBundleOps.ExportCompression.max.tarArgs
+            == ["-J", "--options", "xz:compression-level=9,xz:threads=0"])
+    }
 }


### PR DESCRIPTION
## What

`vphone vm export` hardcoded **xz -9** — the densest but slowest compressor libarchive offers — so every export forced a multi-GB `Disk.img` through the most aggressive setting.

This adds a `--compress` preset so you can trade ratio for speed:

| preset | compressor | notes |
|--------|-----------|-------|
| `fast` | zstd -3 | quickest |
| `balanced` | zstd -19 | **new default** |
| `max` | xz -9 | previous behavior |

```
vphone vm export myphone -o myphone.tzst              # balanced (default)
vphone vm export myphone -o myphone.tzst -c fast
vphone vm export myphone -o myphone.txz  -c max
```

## Why it's dependency-free

All presets are handed to the same system `/usr/bin/tar` (Apple's signed `bsdtar` → `/usr/lib/libarchive.2.dylib`) already used for the xz path. zstd has shipped in that libarchive since macOS 11, so:

- no new project dependency, no bundled binary, no SwiftPM/Homebrew addition
- no raised platform floor (project already targets macOS 15+)

## Import unchanged

`importArchive` already auto-detects the compressor via `tar -tf`/`-xf`, so both the new zstd archives and existing xz archives import with no changes. The only behavior change is the **default output compressor** (xz → zstd); previously-exported xz archives still import fine.

## Tests

Added to `BundleOpsTests`:
- `fast`/`max` each round-trip export → import
- magic-byte assertions prove the algorithm actually switches (zstd `28 b5 2f fd` vs xz `fd 37 7a 58 5a 00`)
- default export is zstd (`balanced`)
- preset → `tar` args mapping

All 21 `BundleOpsTests` pass; `make build` signs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)