### PR TITLE
docs: Add Xcode + iOS SDK to host prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Boot a virtual iPhone via Apple's Virtualization.framework using PCC research VM
 
 - Apple Silicon
 - macOS 15+ (Sequoia)
+- Xcode + iOS SDK (cross-compiles the guest daemon)
 - [SIP/AMFI relaxation to allow private PV=3 entitlements with unsigned-binary](#sipamfi-relaxation)
 
 **Dependencies:**

--- a/docs/README_ja.md
+++ b/docs/README_ja.md
@@ -12,6 +12,7 @@ PCC リサーチ VM インフラストラクチャを使用し、Apple の Virtu
 
 - Apple Silicon
 - macOS 15+ (Sequoia)
+- Xcode + iOS SDK（ゲストデーモンをクロスコンパイルするため）
 - [未署名バイナリでプライベートな PV=3 エンタイトルメントを許可するための SIP/AMFI の緩和](#sipamfi-の緩和)
 
 **依存関係:**

--- a/docs/README_ko.md
+++ b/docs/README_ko.md
@@ -12,6 +12,7 @@ PCC 리서치 VM 인프라를 사용하여 Apple의 Virtualization.framework로 
 
 - Apple Silicon
 - macOS 15+ (Sequoia)
+- Xcode + iOS SDK (게스트 데몬 크로스 컴파일용)
 - [서명되지 않은 바이너리로 private PV=3 권한을 허용하기 위한 SIP/AMFI 완화](#sipamfi-완화)
 
 **의존성:**

--- a/docs/README_zh.md
+++ b/docs/README_zh.md
@@ -12,6 +12,7 @@
 
 - Apple Silicon
 - macOS 15+（Sequoia）
+- Xcode + iOS SDK（用于交叉编译访客守护进程）
 - [放宽 SIP/AMFI，以允许未签名二进制使用私有 PV=3 授权](#放宽-sipamfi)
 
 **依赖：**


### PR DESCRIPTION
## Summary

The build cross-compiles the guest daemon (`vphoned`) for iOS, which requires the iOS SDK bundled with Xcode. This wasn't listed in the prerequisites, so a host without Xcode installed would fail the guest build step.

Adds `Xcode + iOS SDK` to the **Host** prerequisites list in all four READMEs:

- `README.md` (English)
- `docs/README_ja.md` (Japanese)
- `docs/README_ko.md` (Korean)
- `docs/README_zh.md` (Chinese)

Placed after the macOS entry and before the SIP/AMFI link, matching the existing terse list style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)