### PR TITLE
Rework vm export/import: presets, auto-naming, positional import, progress bars

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ vphone-cli vm info myphone                  # show one VM
 vphone-cli vm new myphone                   # create an empty bundle (cpu/mem/disk options)
 vphone-cli vm config myphone --cpu 8 --memory 8192
 vphone-cli vm clone myphone myphone-2       # fast APFS clone, fresh device identity
-vphone-cli vm export myphone --out myphone.tzst   # zstd balanced (--compress fast|balanced|max); skips restore dir + staging files
-vphone-cli vm import --in myphone.tzst --name restored
+vphone-cli vm export myphone --out myphone.tzst   # zstd fast by default (--max = xz -9); --out may be a dir (auto-names <vm>.tzst/.txz); skips restore dir + staging files
+vphone-cli vm import myphone.tzst --name restored
 vphone-cli vm rename myphone iphone16
 vphone-cli vm delete iphone16
 ```

--- a/docs/README_ja.md
+++ b/docs/README_ja.md
@@ -60,8 +60,8 @@ vphone-cli vm info myphone                  # 1 つの VM を表示
 vphone-cli vm new myphone                   # 空のバンドルを作成（cpu/mem/disk オプション）
 vphone-cli vm config myphone --cpu 8 --memory 8192
 vphone-cli vm clone myphone myphone-2       # 高速 APFS クローン、新しいデバイスアイデンティティ
-vphone-cli vm export myphone --out myphone.tzst   # zstd balanced (--compress fast|balanced|max); 復元ディレクトリ + ステージングファイルをスキップ
-vphone-cli vm import --in myphone.tzst --name restored
+vphone-cli vm export myphone --out myphone.tzst   # zstd fast by default (--max = xz -9); --out がディレクトリなら <vm>.tzst/.txz を自動命名; 復元ディレクトリ + ステージングファイルをスキップ
+vphone-cli vm import myphone.tzst --name restored
 vphone-cli vm rename myphone iphone16
 vphone-cli vm delete iphone16
 ```

--- a/docs/README_ko.md
+++ b/docs/README_ko.md
@@ -60,8 +60,8 @@ vphone-cli vm info myphone                  # VM 하나 표시
 vphone-cli vm new myphone                   # 빈 번들 생성 (cpu/mem/disk 옵션)
 vphone-cli vm config myphone --cpu 8 --memory 8192
 vphone-cli vm clone myphone myphone-2       # 빠른 APFS 복제, 새로운 기기 식별자
-vphone-cli vm export myphone --out myphone.tzst   # zstd balanced (--compress fast|balanced|max); restore 디렉토리 + 스테이징 파일 건너뜀
-vphone-cli vm import --in myphone.tzst --name restored
+vphone-cli vm export myphone --out myphone.tzst   # zstd fast by default (--max = xz -9); --out 이 디렉토리면 <vm>.tzst/.txz 자동 명명; restore 디렉토리 + 스테이징 파일 건너뜀
+vphone-cli vm import myphone.tzst --name restored
 vphone-cli vm rename myphone iphone16
 vphone-cli vm delete iphone16
 ```

--- a/docs/README_zh.md
+++ b/docs/README_zh.md
@@ -60,8 +60,8 @@ vphone-cli vm info myphone                  # 显示某台虚拟机
 vphone-cli vm new myphone                   # 创建一个空 bundle（cpu/内存/磁盘选项）
 vphone-cli vm config myphone --cpu 8 --memory 8192
 vphone-cli vm clone myphone myphone-2       # 快速 APFS 克隆，全新设备标识
-vphone-cli vm export myphone --out myphone.tzst   # zstd balanced（--compress fast|balanced|max）；跳过 restore 目录 + 暂存文件
-vphone-cli vm import --in myphone.tzst --name restored
+vphone-cli vm export myphone --out myphone.tzst   # zstd fast by default（--max = xz -9）；--out 为目录时自动命名 <vm>.tzst/.txz；跳过 restore 目录 + 暂存文件
+vphone-cli vm import myphone.tzst --name restored
 vphone-cli vm rename myphone iphone16
 vphone-cli vm delete iphone16
 ```

--- a/sources/VPhoneCore/VPhoneBundleOps.swift
+++ b/sources/VPhoneCore/VPhoneBundleOps.swift
@@ -167,16 +167,23 @@ public enum VPhoneBundleOps {
 
     // MARK: - Export / Import
 
-    /// Compression preset for `export`. All import transparently: `importArchive`
-    /// auto-detects the compressor via `tar -tf`/`-xf`. `threads=0` → all cores.
+    /// Compression preset for `export`. Both import transparently — `importArchive`
+    /// auto-detects the compressor when it extracts. `threads=0` → all cores.
     public enum ExportCompression: String, CaseIterable, Sendable {
-        case fast, balanced, max
+        case fast, max
 
         var tarArgs: [String] {
             switch self {
-            case .fast:     ["--zstd", "--options", "zstd:compression-level=3,zstd:threads=0"]
-            case .balanced: ["--zstd", "--options", "zstd:compression-level=19,zstd:threads=0"]
-            case .max:      ["-J", "--options", "xz:compression-level=9,xz:threads=0"]
+            case .fast: ["--zstd", "--options", "zstd:compression-level=3,zstd:threads=0"]
+            case .max:  ["-J", "--options", "xz:compression-level=9,xz:threads=0"]
+            }
+        }
+
+        /// Extension for auto-named output when `export`'s destination is a directory.
+        public var fileExtension: String {
+            switch self {
+            case .fast: "tzst"
+            case .max:  "txz"
             }
         }
     }
@@ -187,39 +194,83 @@ public enum VPhoneBundleOps {
     /// `Disk.img`). Always excluded.
     static let exportExcludePatterns = ["*.vphoned.signed", "*cfw_input*", "*cfw_jb_input*", "*.cfw_temp*"]
 
+    /// When `to` is an existing directory, the archive is written inside it as
+    /// `<name>.<compression.fileExtension>`. Returns the resolved output URL.
+    ///
+    /// Runs as a two-stage `tar` pipeline (uncompressed producer → compressing
+    /// consumer via bsdtar's `@-`) so `progress` can be driven off the
+    /// uncompressed byte stream: it is called with `(bytesDone, totalBytes)`,
+    /// where `totalBytes` is the bundle's on-disk logical size (minus excludes).
+    @discardableResult
     public static func export(
         bundleNamed name: String, to outFile: URL, includeIPSW: Bool,
-        compression: ExportCompression = .balanced, in library: VPhoneLibrary
-    ) throws {
+        compression: ExportCompression = .fast, in library: VPhoneLibrary,
+        progress: ((Int64, Int64) -> Void)? = nil
+    ) throws -> URL {
         _ = try library.bundle(named: name)  // validate it exists
-        var args = ["-cf", outFile.path] + compression.tarArgs
-        if !includeIPSW { args += ["--exclude", "*_Restore*"] }
-        for pattern in exportExcludePatterns { args += ["--exclude", pattern] }
-        args += ["-C", library.root.path, name]
-        let r = try VPhoneProcessRunner.runCapturing(URL(fileURLWithPath: "/usr/bin/tar"), args)
-        guard r.succeeded else { throw VPhoneBundleOpsError.tarFailed(r.stderr) }
+        var isDir: ObjCBool = false
+        let outFile = FileManager.default.fileExists(atPath: outFile.path, isDirectory: &isDir) && isDir.boolValue
+            ? outFile.appendingPathComponent("\(name).\(compression.fileExtension)")
+            : outFile
+
+        // gnutar (not the bsdtar-default pax): pax extended headers make the
+        // consumer's `@-` reader misbid the stream as mtree ("Line too long")
+        // on large members; gnutar also carries files >8 GB (ustar cannot).
+        var producer = ["--format", "gnutar", "-cf", "-"]
+        if !includeIPSW { producer += ["--exclude", "*_Restore*"] }
+        for pattern in exportExcludePatterns { producer += ["--exclude", pattern] }
+        producer += ["-C", library.root.path, name]
+        let consumer = ["-cf", outFile.path] + compression.tarArgs + ["@-"]
+
+        let total = progress != nil
+            ? archivedLogicalSize(bundleDir: library.url(forName: name), libraryRoot: library.root, includeIPSW: includeIPSW)
+            : 0
+        let err = try VPhoneProcessRunner.runCountingTarPipe(
+            producerArgs: producer, sourceFile: nil, consumerArgs: consumer
+        ) { done in progress?(done, total) }
+        if let err { throw VPhoneBundleOpsError.tarFailed(err) }
+        return outFile
     }
 
+    /// On-disk logical size of the members `export` will archive, mirroring the
+    /// tar `--exclude` patterns so the progress total matches the streamed bytes.
+    private static func archivedLogicalSize(
+        bundleDir: URL, libraryRoot: URL, includeIPSW: Bool
+    ) -> Int64 {
+        let fm = FileManager.default
+        guard let en = fm.enumerator(
+            at: bundleDir,
+            includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey]) else { return 0 }
+        let prefix = libraryRoot.path.count + 1  // members are "<name>/..."
+        var total: Int64 = 0
+        for case let url as URL in en {
+            let rel = String(url.path.dropFirst(prefix))
+            if !includeIPSW, rel.contains("_Restore") { en.skipDescendants(); continue }
+            if exportExcludePatterns.contains(where: { fnmatch($0, rel, 0) == 0 }) { continue }
+            guard let vals = try? url.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey]),
+                  vals.isRegularFile == true else { continue }
+            total += Int64(vals.fileSize ?? 0)
+        }
+        return total
+    }
+
+    /// Extracts (auto-detecting gzip/zstd/xz) into a private staging dir, then
+    /// promotes the single top-level bundle to the library. Extracting first
+    /// means the archive is decompressed once; `progress` is called with
+    /// `(bytesDone, totalBytes)` as the compressed file is fed into `tar -x`,
+    /// where `totalBytes` is the archive's size on disk.
     public static func importArchive(
-        from inFile: URL, name: String?, in library: VPhoneLibrary
+        from inFile: URL, name: String?, in library: VPhoneLibrary,
+        progress: ((Int64, Int64) -> Void)? = nil
     ) throws -> VPhoneBundle {
         let fm = FileManager.default
-        // Auto-detect the compression (-tf, not -tzf) so both legacy gzip and
-        // current xz archives import.
-        let listing = try VPhoneProcessRunner.runCapturing(
-            URL(fileURLWithPath: "/usr/bin/tar"), ["-tf", inFile.path])
-        guard listing.succeeded else { throw VPhoneBundleOpsError.tarFailed(listing.stderr) }
-        let topDirs = Set(listing.stdout.split(whereSeparator: \.isNewline).compactMap {
-            $0.split(separator: "/").first.map(String.init)
-        })
-        guard topDirs.count == 1, let archived = topDirs.first else {
-            throw VPhoneBundleOpsError.badArchive(
-                "expected a single top-level bundle directory, found \(topDirs.sorted())")
+        // Fail fast when the destination name is already known (explicit rename).
+        if let name {
+            try requireValidName(name)
+            if fm.fileExists(atPath: library.url(forName: name).path) {
+                throw VPhoneLibraryError.alreadyExists(name: name)
+            }
         }
-        let finalName = name ?? archived
-        try requireValidName(finalName)
-        let dst = library.url(forName: finalName)
-        if fm.fileExists(atPath: dst.path) { throw VPhoneLibraryError.alreadyExists(name: finalName) }
 
         // Extract into a private staging dir so the archive's OWN top-level name
         // can never clobber/merge into an existing bundle of that name; only the
@@ -229,9 +280,21 @@ public enum VPhoneBundleOps {
         try fm.createDirectory(at: staging, withIntermediateDirectories: true)
         defer { try? fm.removeItem(at: staging) }
 
-        let extract = try VPhoneProcessRunner.runCapturing(
-            URL(fileURLWithPath: "/usr/bin/tar"), ["-xf", inFile.path, "-C", staging.path])
-        guard extract.succeeded else { throw VPhoneBundleOpsError.tarFailed(extract.stderr) }
+        let total = progress != nil ? fileByteSize(inFile) : 0
+        let err = try VPhoneProcessRunner.runCountingTarPipe(
+            producerArgs: nil, sourceFile: inFile, consumerArgs: ["-xf", "-", "-C", staging.path]
+        ) { done in progress?(done, total) }
+        if let err { throw VPhoneBundleOpsError.tarFailed(err) }
+
+        let entries = try fm.contentsOfDirectory(atPath: staging.path)
+        guard entries.count == 1, let archived = entries.first else {
+            throw VPhoneBundleOpsError.badArchive(
+                "expected a single top-level bundle directory, found \(entries.sorted())")
+        }
+        let finalName = name ?? archived
+        try requireValidName(finalName)
+        let dst = library.url(forName: finalName)
+        if fm.fileExists(atPath: dst.path) { throw VPhoneLibraryError.alreadyExists(name: finalName) }
         let extracted = staging.appendingPathComponent(archived)
         guard fm.fileExists(atPath: extracted.appendingPathComponent("config.plist").path) else {
             throw VPhoneBundleOpsError.badArchive(
@@ -239,5 +302,10 @@ public enum VPhoneBundleOps {
         }
         try fm.moveItem(at: extracted, to: dst)
         return try VPhoneBundle.load(at: dst)
+    }
+
+    private static func fileByteSize(_ url: URL) -> Int64 {
+        let size = (try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize
+        return Int64(size ?? 0)
     }
 }

--- a/sources/VPhoneCore/VPhoneProcessRunner.swift
+++ b/sources/VPhoneCore/VPhoneProcessRunner.swift
@@ -79,6 +79,97 @@ public enum VPhoneProcessRunner {
             stderr: String(decoding: errBox.take(), as: UTF8.self))
     }
 
+    /// Stream an archive through a `/usr/bin/tar` consumer that reads on stdin,
+    /// invoking `onBytes` with the running byte total so a caller can drive a
+    /// progress bar off the *uncompressed* (export) or *compressed* (import)
+    /// stream. The byte source is exactly one of:
+    ///   - `producerArgs`: a `tar` producing an uncompressed archive to a pipe
+    ///     (export → count uncompressed input; the consumer compresses via `@-`).
+    ///   - `sourceFile`: the archive file read directly (import → count the file
+    ///     as it is fed into `tar -x`).
+    /// Returns the stderr of whichever stage exited nonzero (consumer first), or
+    /// `nil` on success. SIGPIPE is ignored for the duration so a consumer that
+    /// dies early surfaces as its exit status rather than killing this process.
+    public static func runCountingTarPipe(
+        producerArgs: [String]?,
+        sourceFile: URL?,
+        consumerArgs: [String],
+        onBytes: ((Int64) -> Void)? = nil
+    ) throws -> String? {
+        let tar = URL(fileURLWithPath: "/usr/bin/tar")
+        let prevPIPE = signal(SIGPIPE, SIG_IGN)
+        defer { signal(SIGPIPE, prevPIPE) }
+
+        let group = DispatchGroup()
+
+        let consumer = Process()
+        consumer.executableURL = tar
+        consumer.arguments = consumerArgs
+        let cIn = Pipe()
+        consumer.standardInput = cIn
+        consumer.standardOutput = FileHandle.nullDevice
+        let cErr = Pipe()
+        consumer.standardError = cErr
+        let cErrBox = DataBox()
+        group.enter()
+        cErr.fileHandleForReading.readabilityHandler = { handle in
+            let chunk = handle.availableData
+            if chunk.isEmpty { handle.readabilityHandler = nil; group.leave() }
+            else { cErrBox.append(chunk) }
+        }
+
+        var producer: Process?
+        let source: FileHandle
+        let pErrBox = DataBox()
+        if let producerArgs {
+            let p = Process()
+            p.executableURL = tar
+            p.arguments = producerArgs
+            let pOut = Pipe()
+            p.standardOutput = pOut
+            let pErr = Pipe()
+            p.standardError = pErr
+            group.enter()
+            pErr.fileHandleForReading.readabilityHandler = { handle in
+                let chunk = handle.availableData
+                if chunk.isEmpty { handle.readabilityHandler = nil; group.leave() }
+                else { pErrBox.append(chunk) }
+            }
+            producer = p
+            source = pOut.fileHandleForReading
+        } else if let sourceFile {
+            source = try FileHandle(forReadingFrom: sourceFile)
+        } else {
+            preconditionFailure("runCountingTarPipe: producerArgs or sourceFile required")
+        }
+
+        try consumer.run()
+        try producer?.run()
+
+        let sink = cIn.fileHandleForWriting
+        var total: Int64 = 0
+        while true {
+            guard let chunk = try? source.read(upToCount: 1 << 20), !chunk.isEmpty else { break }
+            do { try sink.write(contentsOf: chunk) } catch { break }  // consumer died; status below
+            total += Int64(chunk.count)
+            onBytes?(total)
+        }
+        try? sink.close()
+        try? source.close()
+
+        producer?.waitUntilExit()
+        consumer.waitUntilExit()
+        group.wait()
+
+        if consumer.terminationStatus != 0 {
+            return String(decoding: cErrBox.take(), as: UTF8.self)
+        }
+        if let producer, producer.terminationStatus != 0 {
+            return String(decoding: pErrBox.take(), as: UTF8.self)
+        }
+        return nil
+    }
+
     /// Run `executable args`, inheriting the parent's stdout/stderr so output
     /// streams live to the terminal (for long-running tools: downloads, restore,
     /// CFW install). Returns the child's exit status; throws only on spawn failure.

--- a/sources/vphone-cli/VPhoneProgressBar.swift
+++ b/sources/vphone-cli/VPhoneProgressBar.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+// MARK: - VPhoneProgressBar
+
+/// A single-line, redrawing byte progress bar for long transfers. Renders to
+/// stderr only when it is a TTY, so piped/`--json`/GUI-subprocess invocations
+/// (stdout consumed elsewhere) stay clean and the bar simply no-ops.
+final class VPhoneProgressBar {
+    private let label: String
+    private let enabled: Bool
+    private let start = Date()
+    private let width = 28
+    private var lastRender = Date.distantPast
+    private var total: Int64 = 0
+
+    init(label: String) {
+        self.label = label
+        self.enabled = isatty(FileHandle.standardError.fileDescriptor) != 0
+    }
+
+    func update(done: Int64, total: Int64) {
+        guard enabled else { return }
+        self.total = total
+        let now = Date()
+        if done < total, now.timeIntervalSince(lastRender) < 0.066 { return }  // ~15 fps
+        lastRender = now
+        render(done: done, now: now)
+    }
+
+    func finish() {
+        guard enabled else { return }
+        render(done: total, now: Date())
+        FileHandle.standardError.write(Data("\n".utf8))
+    }
+
+    private func render(done: Int64, now: Date) {
+        let frac = total > 0 ? min(1.0, Double(done) / Double(total)) : 0
+        let filled = Int(frac * Double(width))
+        let bar = String(repeating: "█", count: filled) + String(repeating: "░", count: width - filled)
+        let elapsed = now.timeIntervalSince(start)
+        let rate = elapsed > 0 ? Double(done) / elapsed : 0
+
+        var line = "\r\(label) [\(bar)] \(Int(frac * 100))%  \(Self.bytes(done))"
+        if total > 0 { line += "/\(Self.bytes(total))" }
+        if rate > 0 { line += "  \(Self.bytes(Int64(rate)))/s" }
+        if total > 0, rate > 0, done < total { line += "  eta \(Self.clock(Double(total - done) / rate))" }
+        line += "\u{1B}[K"  // clear to end of line
+        FileHandle.standardError.write(Data(line.utf8))
+    }
+
+    static func bytes(_ n: Int64) -> String {
+        let units = ["B", "KB", "MB", "GB", "TB"]
+        var value = Double(n), i = 0
+        while value >= 1024, i < units.count - 1 { value /= 1024; i += 1 }
+        return i == 0 ? "\(n) B" : String(format: "%.1f %@", value, units[i])
+    }
+
+    static func clock(_ seconds: Double) -> String {
+        let s = Int(seconds.rounded())
+        return s >= 3600
+            ? String(format: "%d:%02d:%02d", s / 3600, (s % 3600) / 60, s % 60)
+            : String(format: "%02d:%02d", s / 60, s % 60)
+    }
+}

--- a/sources/vphone-cli/VPhoneVMTransferCLI.swift
+++ b/sources/vphone-cli/VPhoneVMTransferCLI.swift
@@ -21,8 +21,6 @@ struct VPhoneVMCloneCommand: ParsableCommand {
     }
 }
 
-extension VPhoneBundleOps.ExportCompression: ExpressibleByArgument {}
-
 struct VPhoneVMExportCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "export", abstract: "Export a VM bundle to a .tgz archive")
@@ -30,16 +28,19 @@ struct VPhoneVMExportCommand: ParsableCommand {
     @OptionGroup var lib: VPhoneLibraryOption
     @Argument(help: "VM name") var name: String?
     @Option(name: .shortAndLong, help: "output archive path") var out: String
-    @Option(name: .shortAndLong, help: "compression preset: fast | balanced | max")
-    var compress: VPhoneBundleOps.ExportCompression = .balanced
+    @Flag(help: "densest compression (xz -9) instead of the default fast (zstd -3)") var max = false
     @Flag(help: "include the *_Restore* IPSW directory") var includeIpsw = false
 
     func run() throws {
         let name = try VPhoneVMSelection.resolveExisting(name, in: lib.library)
-        try VPhoneBundleOps.export(
+        let compression: VPhoneBundleOps.ExportCompression = max ? .max : .fast
+        let bar = VPhoneProgressBar(label: "exporting \(name)")
+        let outURL = try VPhoneBundleOps.export(
             bundleNamed: name, to: URL(fileURLWithPath: out), includeIPSW: includeIpsw,
-            compression: compress, in: lib.library)
-        print("exported \(name) → \(out)")
+            compression: compression, in: lib.library,
+            progress: { done, total in bar.update(done: done, total: total) })
+        bar.finish()
+        print("exported \(name) → \(outURL.path)")
     }
 }
 
@@ -48,12 +49,15 @@ struct VPhoneVMImportCommand: ParsableCommand {
         commandName: "import", abstract: "Import a VM bundle from a .tgz archive")
 
     @OptionGroup var lib: VPhoneLibraryOption
-    @Option(name: [.customShort("i"), .customLong("in")], help: "input archive path") var input: String
+    @Argument(help: "input archive path") var input: String
     @Option(name: .shortAndLong, help: "name for the imported VM (default: the archive's own name)") var name: String?
 
     func run() throws {
+        let bar = VPhoneProgressBar(label: "importing")
         let bundle = try VPhoneBundleOps.importArchive(
-            from: URL(fileURLWithPath: input), name: name, in: lib.library)
+            from: URL(fileURLWithPath: input), name: name, in: lib.library,
+            progress: { done, total in bar.update(done: done, total: total) })
+        bar.finish()
         print("imported → \(bundle.name)")
     }
 }

--- a/tests/VPhoneCoreTests/BundleOpsTests.swift
+++ b/tests/VPhoneCoreTests/BundleOpsTests.swift
@@ -393,7 +393,7 @@ struct BundleOpsTests {
         return (archive, imported)
     }
 
-    @Test func exportDefaultsToBalancedZstd() throws {
+    @Test func exportDefaultsToFastZstd() throws {
         let (archive, imported) = try exportAndImport(nil)
         #expect(try magic(archive, 4) == Self.zstdMagic)
         #expect(imported.manifest.cpuCount == 6)
@@ -411,11 +411,64 @@ struct BundleOpsTests {
         #expect(imported.manifest.cpuCount == 6)
     }
 
+    @Test func exportToDirectoryAutoNamesWithExtension() throws {
+        let root = try makeRoot()
+        let rom = try fakeROM(); let seprom = try fakeROM()
+        let lib = VPhoneLibrary(root: root)
+        _ = try VPhoneBundleOps.create(
+            .init(name: "orig", cpuCount: 6, memoryMB: 2048, diskSizeGB: 1,
+                  romSource: rom, sepromSource: seprom), in: lib)
+        let outDir = try makeRoot()
+        let zstdOut = try VPhoneBundleOps.export(
+            bundleNamed: "orig", to: outDir, includeIPSW: false, in: lib)
+        #expect(zstdOut == outDir.appendingPathComponent("orig.tzst"))
+        #expect(FileManager.default.fileExists(atPath: zstdOut.path))
+        let xzOut = try VPhoneBundleOps.export(
+            bundleNamed: "orig", to: outDir, includeIPSW: false, compression: .max, in: lib)
+        #expect(xzOut == outDir.appendingPathComponent("orig.txz"))
+        #expect(FileManager.default.fileExists(atPath: xzOut.path))
+    }
+
+    @Test func exportAndImportReportProgress() throws {
+        final class Collector {
+            private(set) var dones: [Int64] = []
+            private(set) var total: Int64 = 0
+            func add(_ done: Int64, _ total: Int64) { dones.append(done); self.total = total }
+        }
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let rom = try fakeROM(); let seprom = try fakeROM()
+        let lib = VPhoneLibrary(root: root)
+        _ = try VPhoneBundleOps.create(
+            .init(name: "orig", cpuCount: 6, memoryMB: 2048, diskSizeGB: 1,
+                  romSource: rom, sepromSource: seprom), in: lib)
+
+        let exp = Collector()
+        let archive = root.appendingPathComponent("orig.tzst")
+        try VPhoneBundleOps.export(bundleNamed: "orig", to: archive, includeIPSW: false, in: lib) {
+            exp.add($0, $1)
+        }
+        #expect(!exp.dones.isEmpty)
+        #expect(exp.total > 0)                                   // bundle logical size
+        #expect(exp.dones.last! > 0)
+        #expect(exp.dones == exp.dones.sorted())                 // monotonically non-decreasing
+
+        let imp = Collector()
+        let dstRoot = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: dstRoot) }
+        _ = try VPhoneBundleOps.importArchive(from: archive, name: "copy", in: VPhoneLibrary(root: dstRoot)) {
+            imp.add($0, $1)
+        }
+        let archiveSize = try Data(contentsOf: archive).count
+        #expect(!imp.dones.isEmpty)
+        #expect(imp.total == Int64(archiveSize))                 // total == compressed file size
+        #expect(imp.dones.last! == Int64(archiveSize))           // whole archive fed
+        #expect(imp.dones == imp.dones.sorted())
+    }
+
     @Test func compressionPresetTarArgs() {
         #expect(VPhoneBundleOps.ExportCompression.fast.tarArgs
             == ["--zstd", "--options", "zstd:compression-level=3,zstd:threads=0"])
-        #expect(VPhoneBundleOps.ExportCompression.balanced.tarArgs
-            == ["--zstd", "--options", "zstd:compression-level=19,zstd:threads=0"])
         #expect(VPhoneBundleOps.ExportCompression.max.tarArgs
             == ["-J", "--options", "xz:compression-level=9,xz:threads=0"])
     }


### PR DESCRIPTION
## Summary

Reworks `vphone-cli vm export` / `vm import`:

- **Compression presets** — replaces `--compress {fast,balanced,max}` with a **fast (zstd -3) default** and a single **`--max` (xz -9)** flag; drops `balanced`.
- **Directory auto-naming** — `vm export --out DIR` writes `<vm>.tzst` / `.txz` into the directory (the extension tracks the compressor) and prints the resolved path.
- **Positional import** — `vm import ARCHIVE` takes the archive as a positional argument instead of `--in`.
- **Progress bars** — both commands show a live percentage bar on a TTY, and no-op when piped / `--json` / GUI-subprocess so stdout stays clean.

## How progress stays accurate with no new dependencies

Standalone `zstd`/`xz` aren't on stock macOS, so `/usr/bin/tar` (libarchive) stays the only compressor. To count uncompressed input for an honest export %:

- **Export** runs a two-stage pipeline — `tar --format gnutar -cf -` (uncompressed producer) → a byte counter → `tar <zstd|xz> -cf out @-` (bsdtar repackages + compresses). `gnutar` is required: the pax default makes bsdtar's `@-` reader misbid large members as mtree (`Line too long`), and gnutar also carries files >8 GB (ustar cannot). Final archive format and magic bytes are unchanged.
- **Import** now extracts once (was decompressing twice — a `tar -tf` listing then `tar -xf`), counting the archive as it is fed into `tar -x`. Validation moved to post-extract, preserving fail-fast on an explicit `--name`.

## Tests

`BundleOpsTests` covers the fast-zstd default, `--max` xz, directory auto-naming extensions, and monotonic / correctly-totalled progress callbacks for both directions. All pass; existing round-trip and exclude tests are unchanged.

## Commits

1. Add byte-counting tar pipeline + progress-bar primitives
2. Rework vm export/import — presets, auto-naming, positional, progress
3. Update docs (README + ja/ko/zh)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
